### PR TITLE
fix: broken links in doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,22 +2,28 @@
 
 Documentation of Boavizta tools-API.
 
-Contains : 
-1) ADR - Architecture decision record
+Contains:
+
+1) ADR - Architecture decision records
 2) DEMO - Via swagger
 3) Functional documentation - Equations & key concepts are explained
 4) How to guide - for developers who want to use the API
 
-## Install & launch a documentation server
+## Install & launch a local documentation server
+
 ```bash
-pip install mkdocs
-``` 
+pip install mkdocs mkdocs-render-swagger-plugin
+```
 
-```bash 
+```bash
+# from the root of the cloned repository
+cd docs
 mkdocs serve
-``` 
+```
 
-## Launch using docker container
+Open <http://localhost:8080>
+
+## Access latest published documentation using docker
 
 ```bash
 docker run ghcr.io/boavizta/tools-doc:latest

--- a/docs/docs/introduction/usefull_ressources.md
+++ b/docs/docs/introduction/usefull_ressources.md
@@ -1,15 +1,13 @@
-#Useful resources
-
+# Useful resources
 
 ## From Boavizta
 
-####[Boavizta presentation (pdf)](../assets/Boavizta%20Project.pdf)
+- [Boavizta presentation (pdf)](../assets/Boavizta%20Project.pdf)
 
-####[Boavizta server impact measurement methodology](https://boavizta.cmakers.io/blog/numerique-et-environnement-comment-evaluer-l-empreinte-de-la-fabrication-d-un-serveur-au-dela-des-emissions-de-gaz-a-effet-de-se?token=2112aecb183b1b5d27e137abc61e0f0d39fabf99)
+- [Boavizta server impact measurement methodology](https://boavizta.cmakers.io/blog/empreinte-de-la-fabrication-d-un-serveur)
 
-####[Boavizta environmental footprint database](https://github.com/Boavizta/environmental-footprint-data)
-
+- [Boavizta environmental footprint database](https://github.com/Boavizta/environmental-footprint-data)
 
 ## From Boavizta members
 
-####[Benjamin Davy's work on cloud computing impact measurement methodology](https://medium.com/@benjamin.davy)
+- [Benjamin Davy's work on cloud computing impact measurement methodology](https://medium.com/@benjamin.davy)

--- a/docs/docs/swagger.md
+++ b/docs/docs/swagger.md
@@ -1,1 +1,1 @@
-!!swagger openAPI.json!!
+!!swagger openapi.json!!


### PR DESCRIPTION
- fixes https://github.com/Boavizta/Tools-API/issues/37
- use standard markdown format for lists
- fixes https://github.com/Boavizta/Tools-API/issues/38
- update local documentation setup instructions (missing package for swagger)