### PR TITLE
Cpu die size per core complete update

### DIFF
--- a/boaviztapi/data/components/cpu_manufacture.csv
+++ b/boaviztapi/data/components/cpu_manufacture.csv
@@ -1,66 +1,39 @@
 manufacturer,family,manufacture_date,process,die_size,core_units,die_size_per_core,Source
-Intel,skylake,2017,14,694,28,0.248,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,694,24,0.289,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,694,22,0.315,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,694,20,0.347,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,485,18,0.269,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,485,16,0.303125,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,485,14,0.3464285714,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,485,12,0.404,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,325,10,0.325,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,325,8,0.40625,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,325,6,0.541,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,skylake,2017,14,325,4,0.8125,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)
-Intel,coffee lake,2017,14,126,4,0.315,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake
-Intel,coffee lake,2017,14,149,6,0.248,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake
-Intel,coffee lake,2017,14,174,8,0.218,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lakee
-Intel,broadwell,2014,14,456,24,0.19,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)
-Intel,broadwell,2014,14,456,22,0.207,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,456,20,0.228,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,456,18,0.253,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,456,16,0.285,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,306,14,0.219,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,306,12,0.255,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,246,10,0.246,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,246,8,0.3075,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,246,6,0.41,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,broadwell,2014,14,182,4,0.455,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,haswell,2013,22,622,18,0.346,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,622,16,0.388,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,622,14,0.444,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,622,12,0.518,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,622,10,0.622,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,356,8,0.445,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,haswell,2013,22,356,6,0.593,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,ivy bridge,2011,22,160,4,0.400,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)
-Intel,ivy bridge,2011,22,257,6,0.428,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client))
-Intel,ivy bridge,2011,22,341,10,0.341,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)
-Intel,ivy bridge,2011,22,541,15,0.361,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)
-Intel,sandy bridge,2010,32,216,4,0.540,https://en.wikichip.org/wiki/intel/microarchitectures/sandy_bridge_(client)
-Intel,ice lake,2021,10,370,8,0.430,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,370,10,0.370,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,370,12,0.308,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,370,16,0.231,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,505,18,0.281,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,505,20,0.253,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,505,24,0.210,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,505,26,0.194,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,505,28,0.180,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,640,32,0.200,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,640,36,0.178,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,ice lake,2021,10,640,38,0.168,https://semianalysis.com/intel-icelake-server-die-size-floorplan-inefficiencies-revealed/
-Intel,kaby lake,2017,14,126,4,0.315,https://en.wikichip.org/wiki/intel/microarchitectures/kaby_lake
-Amd,zen2,2019,7,74,4,0.185,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen2,2019,7,74,6,0.123,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen2,2019,7,74,8,0.0925,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen2,2019,7,74,12,0.062,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen2,2019,7,74,16,0.046,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen2,2019,7,74,24,0.031,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,6,0.135,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,8,0.101,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,12,0.0675,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,16,0.051,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,24,0.033,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,24,0.033,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Amd,zen3,2020,7,81,32,0.025,https://www.techarp.com/computer/amd-zen-3-tech-report/
-Annapurna Labs,graviton2,2019,7,457,64,0.0714,https://en.wikichip.org/wiki/annapurna_labs/alpine/alc12b00
+Intel,skylake,2017,14,1.0183,2,0.51,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(client)#Dual-core
+Intel,skylake,2017,14,1.223,4,0.31,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(client)#Quad-core
+Intel,skylake,2017,14,3.2544,10,0.33,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)#Low_Core_Count_.28LCC.29
+Intel,skylake,2017,14,4.85,18,0.27,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)#High_Core_Count_.28HCC.29
+Intel,skylake,2017,14,6.94,28,0.25,https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)#Extreme_Core_Count_.28XCC.29
+Intel,coffee lake,2017,14,1.26,4,0.32,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake#Quad-Core
+Intel,coffee lake,2017,14,1.496,6,0.25,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake#Hexa-Core
+Intel,coffee lake,2017,14,1.74,8,0.22,https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake#Octa-Core
+Intel,broadwell,2014,14,0.82,2,0.41,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)#Dual-core
+Intel,broadwell,2014,14,1.82,4,0.46,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)#Quad-core_Broadwell_with_Iris_Pro_die
+Intel,broadwell,2014,14,2.46,10,0.25,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)#Deca-core_Broadwell
+Intel,broadwell,2014,14,3.0518,14,0.22,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)#Die_Stats
+Intel,broadwell,2014,14,4.5612,24,0.19,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client)#Die_Stats
+Intel,haswell,2013,22,1.81,2,0.91,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)#Dual-core_GT3
+Intel,haswell,2013,22,2.6,4,0.65,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)#Quad-core_GT3
+Intel,haswell,2013,22,3.5552,8,0.44,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)#Octa-core
+Intel,haswell,2013,22,6.22,18,0.35,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)#Octadeca-core
+Intel,ivy bridge,2011,22,1.6,4,0.40,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)#Quad-core_Ivy_Bridge_die
+Intel,ivy bridge,2011,22,5.41,15,0.36,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)#Pentadeca-Core_Ivy_Bridge_die
+Intel,ivy bridge,2011,22,3.41,10,0.34,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)#Deca-core_Ivy_Bridge_Die
+Intel,ivy bridge,2011,22,2.565,6,0.43,https://en.wikichip.org/wiki/intel/microarchitectures/ivy_bridge_(client)#Hexa-core_Ivy_Bridge_Die
+Intel,sandy bridge,2010,32,1.49,2,0.75,https://en.wikichip.org/wiki/intel/microarchitectures/sandy_bridge_(client)#Dual-Core_.28GT2.29
+Intel,sandy bridge,2010,32,2.16,4,0.54,https://en.wikichip.org/wiki/intel/microarchitectures/sandy_bridge_(client)#Quad-Core
+Intel,kaby lake,2017,14,1.26,4,0.32,https://en.wikichip.org/wiki/intel/microarchitectures/kaby_lake
+Intel,ice lake,2019,10,6.28,40,0.16,https://fuse.wikichip.org/news/4734/intel-launches-3rd-gen-ice-lake-xeon-scalable/
+Intel,ice lake,2019,10,1.3,4,0.33,https://medium.com/@ewoutterhoeven/calculating-the-intel-ice-lake-quad-core-die-size-130mm2-ce18a44c5f05
+Intel,ice lake,2019,10,3.7,16,0.23,https://twitter.com/dylan522p/status/1326817993792266241?lang=en
+Intel,ice lake,2019,10,5.05,28,0.18,https://twitter.com/dylan522p/status/1326817993792266241?lang=en
+Intel,ice lake,2019,10,6.3,42,0.15,https://twitter.com/dylan522p/status/1326817993792266241?lang=en
+Amd,zen2,2019,7,13.09,16,0.82,https://www.techarp.com/computer/amd-zen-3-tech-report/ (74mm2*core_units+125mm2)
+Amd,zen2,2019,7,10.13,12,0.84,https://www.techarp.com/computer/amd-zen-3-tech-report/ (74mm2*core_units+125mm2)
+Amd,zen2,2019,7,7.17,8,0.90,https://www.techarp.com/computer/amd-zen-3-tech-report/ (74mm2*core_units+125mm2)
+Amd,zen2,2019,7,5.69,6,0.95,https://www.techarp.com/computer/amd-zen-3-tech-report/ (74mm2*core_units+125mm2)
+Amd,zen3,2020,7,14.162,16,0.89,https://www.techarp.com/computer/amd-zen-3-tech-report/ (80.7mm2*core_units+125mm2)
+Amd,zen3,2020,7,10.934,12,0.91,https://www.techarp.com/computer/amd-zen-3-tech-report/ (80.7mm2*core_units+125mm2)
+Amd,zen3,2020,7,7.706,8,0.96,https://www.techarp.com/computer/amd-zen-3-tech-report/ (80.7mm2*core_units+125mm2)
+Amd,zen3,2020,7,6.092,6,1.02,https://www.techarp.com/computer/amd-zen-3-tech-report/ (80.7mm2*core_units+125mm2)
+Annapurna Labs,graviton2,2019,7,4.5696,64,0.07,https://en.wikichip.org/wiki/annapurna_labs/alpine/alc12b00

--- a/boaviztapi/data/components/missing_cpu_manufacture.csv
+++ b/boaviztapi/data/components/missing_cpu_manufacture.csv
@@ -1,25 +1,5 @@
-Intel,Cascade Lake,2019,14,unknown,56,unknown,
-Intel,Cascade Lake,2019,14,unknown,48,unknown,
-Intel,Cascade Lake,2019,14,unknown,32,unknown,
-Intel,Cascade Lake,2019,14,unknown,28,unknown,
-Intel,Cascade Lake,2019,14,unknown,26,unknown,
-Intel,Cascade Lake,2019,14,unknown,24,unknown,
-Intel,Cascade Lake,2019,14,unknown,22,unknown,
-Intel,Cascade Lake,2019,14,unknown,20,unknown,
-Intel,Cascade Lake,2019,14,unknown,18,unknown,
-Intel,Cascade Lake,2019,14,unknown,16,unknown,
-Intel,Cascade Lake,2019,14,unknown,12,unknown,
-Intel,Cascade Lake,2019,14,unknown,10,unknown,
-Intel,Cascade Lake,2019,14,unknown,8,unknown,
-Intel,Cascade Lake,2019,14,unknown,6,unknown,
-Intel,Cascade Lake,2019,14,unknown,4,unknown,
-Intel,Cascade Lake,2019,14,unknown,2,unknown,
-Annapurna Labs,Graviton,2018,16,unknown,16,unknown,
-Intel,Kaby Lake,2017,14,unknown,2,unknown,
-Amd,Zen,2017,7,unknown,8,unknown,
-Intel,Sandy Bridge,2010,32,unknown,2,unknown,
-Intel,Haswell,2013,22,unknown,4,unknown,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,Haswell,2013,22,unknown,2,unknown,https://en.wikichip.org/wiki/intel/microarchitectures/haswell_(client)
-Intel,Broadwell,2014,14,unknown,2,unknown,https://en.wikichip.org/wiki/intel/microarchitectures/broadwell_(client))
-Intel,Coffee Lake,2017,14,unknown,2,unknown,
-
+Intel,cascadelake,2019,14
+Annapurna Labs,Graviton,2018,?
+Amd,Zen,2017,7
+Intel,cooperlake,2020,14
+AMD,Zen+,2018,12

--- a/boaviztapi/dto/component/cpu.py
+++ b/boaviztapi/dto/component/cpu.py
@@ -1,6 +1,7 @@
 import os
 from typing import Optional, Tuple
 
+import numpy as np
 import pandas as pd
 from rapidfuzz import fuzz, process
 
@@ -32,19 +33,27 @@ def smart_mapper_cpu(cpu_dto: CPU) -> ComponentCPU:
     cpu_component.units = cpu_dto.units
 
     if cpu_dto.name is not None:
-        manufacturer, model_range, family = attributes_from_cpu_name(cpu_dto.name)
+        manufacturer, model_range, family, tdp = attributes_from_cpu_name(cpu_dto.name)
         if manufacturer is not None:
             cpu_dto.manufacturer = manufacturer
             cpu_component.manufacturer.value = manufacturer
             cpu_component.manufacturer.status = Status.COMPLETED
+            cpu_component.manufacturer.source = "from name"
         if model_range is not None:
             cpu_dto.model_range = model_range
             cpu_component.model_range.value = model_range
             cpu_component.model_range.status = Status.COMPLETED
+            cpu_component.model_range.source = "from name"
         if family is not None:
             cpu_dto.family = family
             cpu_component.family.value = family
             cpu_component.family.status = Status.COMPLETED
+            cpu_component.family.source = "from name"
+        if tdp is not None:
+            cpu_dto.tdp = tdp
+            cpu_component.tdp.value = tdp
+            cpu_component.tdp.status = Status.COMPLETED
+            cpu_component.tdp.source = "from name"
 
     if cpu_dto.family is not None and cpu_component.family.status != Status.COMPLETED:
         cpu_component.family.value = cpu_dto.family
@@ -54,16 +63,20 @@ def smart_mapper_cpu(cpu_dto: CPU) -> ComponentCPU:
         cpu_component.core_units.value = cpu_dto.core_units
         cpu_component.core_units.status = Status.INPUT
 
-    if cpu_dto.tdp is not None:
+    if cpu_dto.tdp is not None and cpu_component.tdp.status != Status.COMPLETED:
         cpu_component.tdp.value = cpu_dto.tdp
         cpu_component.tdp.status = Status.INPUT
 
-    if cpu_dto.model_range is not None:
+    if cpu_dto.model_range is not None and cpu_component.model_range.status != Status.COMPLETED:
         cpu_component.model_range.value = cpu_dto.model_range
         cpu_component.model_range.status = Status.INPUT
 
     if cpu_dto.die_size_per_core is not None:
         cpu_component.die_size_per_core.value = cpu_dto.die_size_per_core
+        cpu_component.die_size_per_core.status = Status.INPUT
+
+    if cpu_dto.die_size_per_core is not None:
+        cpu_component.core_units.value = cpu_dto.core_units
         cpu_component.die_size_per_core.status = Status.INPUT
 
     elif cpu_dto.die_size is not None and cpu_dto.core_units is not None:
@@ -82,42 +95,31 @@ def smart_mapper_cpu(cpu_dto: CPU) -> ComponentCPU:
             if len(tmp) > 0:
                 sub = tmp.copy()
 
-        if cpu_dto.core_units is not None:
-            tmp = sub[sub['core_units'] == cpu_dto.core_units]
-            if len(tmp) > 0:
-                sub = tmp.copy()
-
         if len(sub) == 0 or len(sub) == len(_cpu_df):
             pass
-        elif len(sub) == 1:
-            cpu_component.die_size_per_core.value = float(sub['die_size_per_core'])
-            cpu_component.die_size_per_core.status = Status.COMPLETED
-            cpu_component.die_size_per_core.source = str(sub['Source'].iloc[0])
-        else:
-            sub['_scope3'] = sub[['core_units', 'die_size_per_core']].apply(lambda x: x[0] * x[1], axis=1)
-            sub = sub.sort_values(by='_scope3', ascending=False)
+
+        elif cpu_dto.core_units is not None:
+            # Find the closest line to the number of cores provided by the user
+            sub['core_dif'] = sub[['core_units']].apply(lambda x: abs(x[0] - cpu_dto.core_units), axis=1)
+            sub = sub.sort_values(by='core_dif', ascending=True)
             row = sub.iloc[0]
 
             cpu_component.die_size_per_core.value = float(row['die_size_per_core'])
+            cpu_component.die_size_per_core.status = Status.COMPLETED
             cpu_component.die_size_per_core.source = row['Source']
 
-            if cpu_dto.die_size_per_core is None:
-                cpu_component.die_size_per_core.status = Status.COMPLETED
-            else:
-                cpu_component.die_size_per_core.status = Status.CHANGED
-
-            cpu_component.core_units.value = int(row['core_units'])
-            cpu_component.core_units.source = row['Source']
-
-            if cpu_dto.core_units is None:
-                cpu_component.core_units.status = Status.COMPLETED
-            else:
-                cpu_component.core_units.status = Status.CHANGED
+        else:
+            # Maximize die_size_per_core
+            sub = sub.sort_values(by='die_size_per_core', ascending=False)
+            row = sub.iloc[0]
+            cpu_component.die_size_per_core.value = float(row['die_size_per_core'])
+            cpu_component.die_size_per_core.status = Status.COMPLETED
+            cpu_component.die_size_per_core.source = row['Source'] + "- maximizing value without core_unit given"
 
     return cpu_component
 
 
-def attributes_from_cpu_name(cpu_name: str) -> [str, str, str]:
+def attributes_from_cpu_name(cpu_name: str) -> [str, str, str, int]:
     cpu_name = cpu_name.lower()
     manufacturer, cpu_sub_name = parse(cpu_name)
     sub = _cpu_index
@@ -126,14 +128,20 @@ def attributes_from_cpu_name(cpu_name: str) -> [str, str, str]:
     else:
         name_list = list(sub[sub['manufacturer'] == manufacturer].sub_model_name.unique())
     result = fuzzymatch(cpu_sub_name, name_list)
+
     if result is not None:
         model_range = sub[sub['sub_model_name'] == result[0]].iloc[0].model_range
         family = sub[sub['sub_model_name'] == result[0]].iloc[0].family
+        tdp = sub[sub['sub_model_name'] == result[0]].iloc[0].tdp
+        if np.isnan(tdp):
+            tdp = None
+
     else:
         model_range = None
         family = None
+        tdp = None
 
-    return manufacturer, model_range, family
+    return manufacturer, model_range, family, tdp
 
 
 def parse(cpu_name: str) -> Tuple[str, str]:

--- a/docs/docs/Explanations/components/cpu.md
+++ b/docs/docs/Explanations/components/cpu.md
@@ -6,10 +6,10 @@
 |-------------------|------|---------------|-----------------------------------------------|--------------------|
 | units             | None | 1             | CPU quantity                                  | 2                  |
 | usage             | None | See Usage     | See usage                                     | ..                 |
-| core_units        | None | 24            | Number of core on one CPU                     | 12                 |
-| die_size          | mm2  | None          | Size of the die                               | 2900               |
+| core_units        | None | 24            | Number of physical core on one CPU            | 12                 |
+| die_size          | cm2  | None          | Size of the die                               | 1.1                |
 | manufacturer      | None | Intel         | Name of the CPU manufacturer                  | AMD                |
-| die_size_per_core | mm2  | 0.245         | Size of the die divided by the number of core | 0.245              |
+| die_size_per_core | cm2  | 0.245         | Size of the die divided by the number of core | 0.245              |
 | model_range       | None | Xeon Platinum | Name of the cpu range or brand                | i7                 |
 | family            | None | Skylake       | Name of the architectural family (Generation) | Naple              |
 | name              | None | None          | Complete commercial name of the CPU           | Intel Core i7-1065 |
@@ -26,8 +26,8 @@ if ```die_size``` and ```core_units``` are given :
 
 $$ \text{die_size_per_core} = \frac{\text{core_units}}{\text{die_size}}$$
 
-Otherwise, if ```family``` or/and ```core_units``` are given, ```die_size_per_core``` can be retrieved from a fuzzy matching on our cpu repository.
-If several cpu matches the given ```family``` and/or ```core_units``` the maximizing value is given (in terms of impacts).
+Otherwise, if ```family``` is given, ```die_size_per_core``` can be retrieved from a fuzzy matching on our cpu repository.
+If several cpu matches the given ```family```, the closest value in terms of ```core_units``` is used (if ```core_units``` given by the user). Otherwise, the maximizing value is given (in terms of impacts).
 
 If no cpu is found either because the cpu is unknown or not enough data have been given by the user the default data are used.
 

--- a/tests/api/test_cloud.py
+++ b/tests/api/test_cloud.py
@@ -37,8 +37,8 @@ async def test_empty_usage_1():
         res = await ac.get('/v1/cloud/?verbose=false&instance_type=a1.2xlarge&provider=aws')
 
     assert res.json() == {'adp': {'manufacture': 0.05, 'unit': 'kgSbeq', 'use': 1.94e-05},
-                         'gwp': {'manufacture': 250.0, 'unit': 'kgCO2eq', 'use': 110.0},
-                         'pe': {'manufacture': 3500.0, 'unit': 'MJ', 'use': 3895.0}}
+                         'gwp': {'manufacture': 300.0, 'unit': 'kgCO2eq', 'use': 110.0},
+                         'pe': {'manufacture': 3000.0, 'unit': 'MJ', 'use': 3895.0}}
 
 @pytest.mark.asyncio
 async def test_empty_usage_2():
@@ -167,8 +167,8 @@ async def test_legacy_empty_usage_1():
         res = await ac.post('/v1/cloud/aws?verbose=false&instance_type=a1.2xlarge', json={})
 
     assert res.json() == {'adp': {'manufacture': 0.05, 'unit': 'kgSbeq', 'use': 1.94e-05},
-                         'gwp': {'manufacture': 250.0, 'unit': 'kgCO2eq', 'use': 110.0},
-                         'pe': {'manufacture': 3500.0, 'unit': 'MJ', 'use': 3895.0}}
+                         'gwp': {'manufacture': 300.0, 'unit': 'kgCO2eq', 'use': 110.0},
+                         'pe': {'manufacture': 3000.0, 'unit': 'MJ', 'use': 3895.0}}
 
 @pytest.mark.asyncio
 async def test_legacy_empty_usage_2():

--- a/tests/api/test_component.py
+++ b/tests/api/test_component.py
@@ -124,8 +124,8 @@ async def test_incomplete_cpu_verbose():
             "core_units": 24, "family": "Skylake", "manufacture_date": 2017})
 
     assert res.json() == {'impacts': {'adp': {'manufacture': 0.02, 'unit': 'kgSbeq', 'use': 0.000102},
-                                      'gwp': {'manufacture': 23.8, 'unit': 'kgCO2eq', 'use': 610.0},
-                                      'pe': {'manufacture': 353.0, 'unit': 'MJ', 'use': 20550.0}},
+                                      'gwp': {'manufacture': 22.0, 'unit': 'kgCO2eq', 'use': 610.0},
+                                      'pe': {'manufacture': 330.0, 'unit': 'MJ', 'use': 20550.0}},
                           'verbose': {'USAGE': {'adp_factor': {'source': 'ADEME BASE IMPACT',
                                                                'status': 'COMPLETED',
                                                                'unit': 'KgSbeq/kWh',
@@ -177,17 +177,17 @@ async def test_incomplete_cpu_verbose():
                                                      'unit': 'none',
                                                      'value': 24},
                                       'die_size_per_core': {
-                                          'source': 'https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)',
+                                          'source': 'https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)#Extreme_Core_Count_.28XCC.29',
                                           'status': 'COMPLETED',
                                           'unit': 'mm2',
-                                          'value': 0.289},
+                                          'value': 0.25},
                                       'family': {'source': None,
                                                  'status': 'CHANGED',
                                                  'unit': 'none',
                                                  'value': 'skylake'},
                                       'manufacture_impacts': {'adp': {'unit': 'kgSbeq', 'value': 0.02},
-                                                              'gwp': {'unit': 'kgCO2eq', 'value': 23.8},
-                                                              'pe': {'unit': 'MJ', 'value': 353.0}},
+                                                              'gwp': {'unit': 'kgCO2eq', 'value': 22.0},
+                                                              'pe': {'unit': 'MJ', 'value': 330.0}},
                                       'units': 1}}
 
 
@@ -198,8 +198,8 @@ async def test_incomplete_cpu_verbose_2():
             "core_units": 24, "family": "skylak", "manufacture_date": 2017})
 
     assert res.json() == {'impacts': {'adp': {'manufacture': 0.02, 'unit': 'kgSbeq', 'use': 0.000102},
-                                      'gwp': {'manufacture': 23.8, 'unit': 'kgCO2eq', 'use': 610.0},
-                                      'pe': {'manufacture': 353.0, 'unit': 'MJ', 'use': 20550.0}},
+                                      'gwp': {'manufacture': 22.0, 'unit': 'kgCO2eq', 'use': 610.0},
+                                      'pe': {'manufacture': 330.0, 'unit': 'MJ', 'use': 20550.0}},
                           'verbose': {'USAGE': {'adp_factor': {'source': 'ADEME BASE IMPACT',
                                                                'status': 'COMPLETED',
                                                                'unit': 'KgSbeq/kWh',
@@ -251,17 +251,17 @@ async def test_incomplete_cpu_verbose_2():
                                                      'status': 'INPUT',
                                                      'unit': 'none',
                                                      'value': 24},
-                                      'die_size_per_core': {'source': 'https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)',
+                                      'die_size_per_core': {'source': 'https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server)#Extreme_Core_Count_.28XCC.29',
                                           'status': 'COMPLETED',
                                           'unit': 'mm2',
-                                          'value': 0.289},
+                                          'value': 0.25},
                                       'family': {'source': None,
                                                  'status': 'CHANGED',
                                                  'unit': 'none',
                                                  'value': 'skylake'},
                                       'manufacture_impacts': {'adp': {'unit': 'kgSbeq', 'value': 0.02},
-                                                              'gwp': {'unit': 'kgCO2eq', 'value': 23.8},
-                                                              'pe': {'unit': 'MJ', 'value': 353.0}},
+                                                              'gwp': {'unit': 'kgCO2eq', 'value': 22.0},
+                                                              'pe': {'unit': 'MJ', 'value': 330.0}},
                                       'units': 1}}
 
 


### PR DESCRIPTION
## Problem

The auto-completion process for CPU ```die_size_per_core``` was implemented as follows : 

We have listed in cpu_manufacture.csv the die size per core for each CPU architecture, for each number of cores. We used data from several sources to identify the ```die_size_per_core```. 

This implementation as several problems :

* Usually, only few die sizes by core_units are available for one architecture. To get the other die sizes (for each number of core units available) we made the assumption that the available die sizes were steps and that the chips under each of the steps had the same die size as the upper step. **This is false**. The relationship between the number of cores and the die area is close to an affine function and not a step function.
* When the user gave their number of cores, but we didn't have the specific die sizes in cpu_manufacture.csv we changed the number of cores to match a die sizes available in cpu_manufacture.csv. This lead to very large changes in user request since only few die sizes were available.

## This PR correct those issues.

1. cpu_manufacture.csv contains only  ```die_size_per_core``` for available data. No assumption are made to retrieve other die sizes.
2. If ```core_units``` is given by the user, the closest ```die_size_per_core``` in terms of ```core_units``` is used ```min(abs(core_unit - cpu_manufacture.csv.core_units))```. Otherwise, the maximizing ```die_size_per_core``` is used.
3. We always use and never change ```core_units``` if given by the user. When evaluating the die size of a CPU we use the ```die_size_per_core``` retrieve during the completion process and the ```core_units``` given by the user or set by default.

