### PR TITLE
fix: typo in examples generates invalid open api spec.

### DIFF
--- a/boaviztapi/routers/component_router.py
+++ b/boaviztapi/routers/component_router.py
@@ -42,7 +42,7 @@ async def cpu_all_archetype_name():
 
 @component_router.get('/cpu/archetype_config',
                        description=cpu_description)
-async def cpu_archetype_config(archetype: str = Query(Exemple=config["default_cpu"])):
+async def cpu_archetype_config(archetype: str = Query(example=config["default_cpu"])):
     archetype_config = get_archetype_config(archetype,"cpu")
     return archetype_config
 
@@ -95,7 +95,7 @@ async def ram_all_archetype_name():
 
 @component_router.get('/ram/archetype_config',
                        description=ram_description)
-async def ram_archetype_config(archetype: str = Query(Exemple=config["default_ram"])):
+async def ram_archetype_config(archetype: str = Query(example=config["default_ram"])):
     archetype_config = get_archetype_config(archetype,"ram")
     return archetype_config
 
@@ -148,7 +148,7 @@ async def ssd_all_archetype_name():
 
 @component_router.get('/ssd/archetype_config',
                        description=ssd_description)
-async def ssd_archetype_config(archetype: str = Query(Exemple=config["default_ssd"])):
+async def ssd_archetype_config(archetype: str = Query(example=config["default_ssd"])):
     archetype_config = get_archetype_config(archetype,"ssd")
     return archetype_config
 
@@ -204,7 +204,7 @@ async def hdd_all_archetype_name():
 
 @component_router.get('/hdd/archetype_config',
                        description=hdd_description)
-async def hdd_archetype_config(archetype: str = Query(Exemple=config["default_hdd"])):
+async def hdd_archetype_config(archetype: str = Query(example=config["default_hdd"])):
     archetype_config = get_archetype_config(archetype,"hdd")
     return archetype_config
 
@@ -260,7 +260,7 @@ async def motherboard_all_archetype_name():
 
 @component_router.get('/motherboard/archetype_config',
                        description=motherboard_description)
-async def motherboard_archetype_config(archetype: str = Query(Exemple=config["default_motherboard"])):
+async def motherboard_archetype_config(archetype: str = Query(example=config["default_motherboard"])):
     archetype_config = get_archetype_config(archetype,"motherboard")
     return archetype_config
 
@@ -304,7 +304,7 @@ async def power_supply_all_archetype_name():
 
 @component_router.get('/power_supply/archetype_config',
                        description=power_supply_description)
-async def power_supply_archetype_config(archetype: str = Query(Exemple=config["default_power_supply"])):
+async def power_supply_archetype_config(archetype: str = Query(example=config["default_power_supply"])):
     archetype_config = get_archetype_config(archetype,"power_supply")
     return archetype_config
 
@@ -360,7 +360,7 @@ async def case_all_archetype_name():
 
 @component_router.get('/case/archetype_config',
                        description=case_description)
-async def case_archetype_config(archetype: str = Query(Exemple=config["default_case"])):
+async def case_archetype_config(archetype: str = Query(example=config["default_case"])):
     archetype_config = get_archetype_config(archetype,"case")
     return archetype_config
 

--- a/boaviztapi/routers/server_router.py
+++ b/boaviztapi/routers/server_router.py
@@ -26,7 +26,7 @@ async def server_get_all_archetype_name():
 
 @server_router.get('/archetype_config',
                    description=get_archetype_config_desc)
-async def get_archetype_config(archetype: str = Query(exemple=config["default_server"])):
+async def get_archetype_config(archetype: str = Query(example=config["default_server"])):
     result = get_server_archetype(archetype)
     if not result:
         raise HTTPException(status_code=404, detail=f"{archetype} not found")


### PR DESCRIPTION
Closes #195