### PR TITLE
Fix rounding USAGE.instance_per_server

### DIFF
--- a/boaviztapi/data/archetypes/cloud/aws.csv
+++ b/boaviztapi/data/archetypes/cloud/aws.csv
@@ -8,16 +8,16 @@ a1.xlarge,AWS,rack,2018,4,16,1,16,Graviton,Annapurna Labs,Graviton,Graviton,40,2
 c1.medium,AWS,rack,2008,2,48,2,12,Xeon E5-2651 v2,intel,xeon e5,ivybridge,95,2008,2,2,21,1,350,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c1.xlarge,AWS,rack,2008,8,48,2,12,Xeon E5-2651 v2,intel,xeon e5,ivybridge,95,2008,7,2,21,4,420,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c3.2xlarge,AWS,rack,2013,8,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,15,2,30,2,80,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-c3.4xlarge,AWS,rack,2013,16,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,30,2,30,2,160,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-c3.8xlarge,AWS,rack,2013,32,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,60,2,30,2,320,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+c3.4xlarge,AWS,rack,2013,16,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,30,2,30,2,160,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+c3.8xlarge,AWS,rack,2013,32,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,60,2,30,2,320,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c3.large,AWS,rack,2013,2,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,4,2,30,2,16,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c3.xlarge,AWS,rack,2013,4,40,2,10,Xeon E5-2680 v2,intel,xeon e5,ivybridge,115,2013,8,2,30,2,40,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c4.2xlarge,AWS,rack,2015,8,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,15,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c4.2xlarge.elasticsearch,AWS,rack,2015,8,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,15,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-c4.4xlarge,AWS,rack,2015,16,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,30,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-c4.4xlarge.elasticsearch,AWS,rack,2015,16,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,30,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-c4.8xlarge,AWS,rack,2015,36,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,60,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-c4.8xlarge.elasticsearch,AWS,rack,2015,36,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,60,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+c4.4xlarge,AWS,rack,2015,16,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,30,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+c4.4xlarge.elasticsearch,AWS,rack,2015,16,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,30,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+c4.8xlarge,AWS,rack,2015,36,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,60,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,1.111111,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+c4.8xlarge.elasticsearch,AWS,rack,2015,36,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,60,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,1.111111,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c4.large,AWS,rack,2015,2,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,4,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c4.large.elasticsearch,AWS,rack,2015,2,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,t,4,32,2,0,0,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c4.xlarge,AWS,rack,2015,4,40,2,10,Xeon E5-2666 v3,intel,xeon e5,haswell,135,2015,8,2,30,0,0,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -28,8 +28,8 @@ c5.18xlarge.elasticsearch,AWS,rack,2019,72,72,2,18,Xeon Platinum 8124M,intel,xeo
 c5.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,cascadelake,240,2019,192,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5.2xlarge,AWS,rack,2016,8,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,16,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5.2xlarge.elasticsearch,AWS,rack,2016,8,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,16,32,6,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-c5.4xlarge,AWS,rack,2016,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,32,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
-c5.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,32,32,6,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+c5.4xlarge,AWS,rack,2016,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,32,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
+c5.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,32,32,6,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c5.9xlarge,AWS,rack,2019,36,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2019,72,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5.9xlarge.elasticsearch,AWS,rack,2019,36,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2019,72,32,6,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c5.large,AWS,rack,2016,2,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,4,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -38,7 +38,7 @@ c5.metal,AWS,rack,2019,96,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,casca
 c5.xlarge,AWS,rack,2016,4,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,8,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5.xlarge.elasticsearch,AWS,rack,2016,4,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2016,8,32,6,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c5a.12xlarge,AWS,rack,2020,48,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,96,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-c5a.16xlarge,AWS,rack,2020,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,128,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c5a.16xlarge,AWS,rack,2020,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,128,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5a.24xlarge,AWS,rack,2020,96,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,192,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5a.2xlarge,AWS,rack,2020,8,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,16,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5a.4xlarge,AWS,rack,2020,16,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,32,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -46,7 +46,7 @@ c5a.8xlarge,AWS,rack,2020,32,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,64,16,12,0
 c5a.large,AWS,rack,2020,2,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,4,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5a.xlarge,AWS,rack,2020,4,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,8,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5ad.12xlarge,AWS,rack,2020,48,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,96,16,12,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-c5ad.16xlarge,AWS,rack,2020,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,128,16,12,2,1200,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c5ad.16xlarge,AWS,rack,2020,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,128,16,12,2,1200,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5ad.24xlarge,AWS,rack,2020,96,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,192,16,12,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5ad.2xlarge,AWS,rack,2020,8,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,16,16,12,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5ad.4xlarge,AWS,rack,2020,16,96,1,48,EPYC 7R32,amd,epyc,rome,280,2020,32,16,12,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -57,20 +57,20 @@ c5d.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,c
 c5d.18xlarge,AWS,rack,2018,72,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,144,16,12,2,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,cascadelake,240,2019,192,16,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.2xlarge,AWS,rack,2018,8,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,16,16,12,1,200,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,
-c5d.4xlarge,AWS,rack,2018,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,32,16,12,1,400,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c5d.4xlarge,AWS,rack,2018,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,32,16,12,1,400,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.9xlarge,AWS,rack,2018,36,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,72,16,12,1,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.large,AWS,rack,2018,2,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,4,16,12,1,50,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.metal,AWS,rack,2019,96,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,cascadelake,240,2019,192,16,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5d.xlarge,AWS,rack,2018,4,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,8,16,12,1,100,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.18xlarge,AWS,rack,2018,72,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,192,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.2xlarge,AWS,rack,2018,8,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,21,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,
-c5n.4xlarge,AWS,rack,2018,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,42,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c5n.4xlarge,AWS,rack,2018,16,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,42,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.9xlarge,AWS,rack,2018,36,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,96,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.large,AWS,rack,2018,2,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,5,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.metal,AWS,rack,2019,72,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2019,192,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c5n.xlarge,AWS,rack,2018,4,72,2,18,Xeon Platinum 8124M,intel,xeon platinum,skylake,240,2018,11,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,
-c6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
-c6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+c6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
+c6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6g.2xlarge.elasticsearch,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -84,7 +84,7 @@ c6g.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 c6g.metal,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6g.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6g.xlarge.elasticsearch,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-c6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,2,1435,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,2,1435,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gd.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,16,8,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gd.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,16,8,1,474,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gd.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,16,8,1,950,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -93,7 +93,7 @@ c6gd.large,AWS,rack,2019,2,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 c6gd.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,2,16,8,1,59,0,0,,,,,2;2;2,2.99;1;5,64,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gd.metal,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,16,8,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gd.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,16,8,1,232,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
-c6gn.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+c6gn.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,96,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gn.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gn.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gn.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -102,9 +102,9 @@ c6gn.large,AWS,rack,2019,2,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 c6gn.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,2,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,64,50;0;100,1,35040,0.33;0.2;0.6,0,
 c6gn.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,16,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
 cache.m3.medium,AWS,rack,2014,1,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2014,4,32,12,1,4,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,155,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,155,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.200000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m4.2xlarge,AWS,rack,2015,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,30,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,61,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,61,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m4.large,AWS,rack,2015,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,6,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m4.xlarge,AWS,rack,2015,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,14,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m5.12xlarge,AWS,rack,2017,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,157,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -113,7 +113,7 @@ cache.m5.2xlarge,AWS,rack,2017,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinu
 cache.m5.4xlarge,AWS,rack,2017,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,52,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m5.large,AWS,rack,2017,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,6,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m5.xlarge,AWS,rack,2017,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,13,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m6g.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -121,10 +121,10 @@ cache.m6g.8xlarge,AWS,rack,2019,32,64,1,64,Graviton2,Annapurna Labs,Graviton2,Gr
 cache.m6g.large,AWS,rack,2019,2,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.m6g.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r3.2xlarge,AWS,rack,2014,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,61,4,61,1,160,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,407,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,407,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r4.2xlarge,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,50,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,101,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-cache.r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,203,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,101,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+cache.r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,203,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r4.large,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,12,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r4.xlarge,AWS,rack,2016,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,25,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r5.12xlarge,AWS,rack,2018,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,318,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -133,7 +133,7 @@ cache.r5.2xlarge,AWS,rack,2018,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum
 cache.r5.4xlarge,AWS,rack,2018,16,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,106,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r5.large,AWS,rack,2018,2,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,13,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r5.xlarge,AWS,rack,2018,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,26,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-cache.r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+cache.r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 cache.r6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 cache.r6g.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -150,7 +150,7 @@ cc2.8xlarge,AWS,rack,2011,32,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2
 cr1.8xlarge,AWS,rack,2013,32,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2013,244,4,61,2,120,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 d2.2xlarge,AWS,rack,2015,8,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,61,4,61,0,0,6,2000,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 d2.4xlarge,AWS,rack,2015,16,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,122,4,61,0,0,1,2000,,,,,2;2;2,2.99;1;5,3,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-d2.8xlarge,AWS,rack,2015,36,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,244,4,61,0,0,2,2000,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+d2.8xlarge,AWS,rack,2015,36,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,244,4,61,0,0,2,2000,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 d2.xlarge,AWS,rack,2015,4,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,31,4,61,0,0,3,2000,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 d3.2xlarge,AWS,rack,2020,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,64,32,8,0,0,6,2000,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 d3.4xlarge,AWS,rack,2020,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,128,32,8,0,0,1,2000,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -173,21 +173,21 @@ db.m3.2xlarge,AWS,rack,2012,8,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,
 db.m3.large,AWS,rack,2014,2,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2014,8,8,30,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m3.medium,AWS,rack,2014,1,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2014,4,8,30,0,0,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m3.xlarge,AWS,rack,2012,4,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2012,15,8,30,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-db.m4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.200000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+db.m4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m4.2xlarge,AWS,rack,2015,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m4.large,AWS,rack,2015,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,8,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m4.xlarge,AWS,rack,2015,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.12xlarge,AWS,rack,2017,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.m5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.m5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.24xlarge,AWS,rack,2017,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,384,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.2xlarge,AWS,rack,2017,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.4xlarge,AWS,rack,2017,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,64,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.8xlarge,AWS,rack,2019,32,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,128,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,3,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.large,AWS,rack,2017,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,8,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m5.xlarge,AWS,rack,2017,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m6g.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -195,25 +195,25 @@ db.m6g.8xlarge,AWS,rack,2019,32,64,1,64,Graviton2,Annapurna Labs,Graviton2,Gravi
 db.m6g.large,AWS,rack,2019,2,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,8,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.m6g.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r3.2xlarge,AWS,rack,2014,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,61,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.r3.4xlarge,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-db.r3.8xlarge,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.r3.4xlarge,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+db.r3.8xlarge,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r3.large,AWS,rack,2014,2,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,15,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r3.xlarge,AWS,rack,2014,4,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,31,4,61,0,0,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r4.2xlarge,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-db.r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+db.r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r4.large,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,15,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r4.xlarge,AWS,rack,2016,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,31,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.12xlarge,AWS,rack,2018,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.r5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.r5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.24xlarge,AWS,rack,2018,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.2xlarge,AWS,rack,2018,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.4xlarge,AWS,rack,2018,16,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,128,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.8xlarge,AWS,rack,2019,32,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,256,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,3,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.large,AWS,rack,2018,2,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,16,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r5.xlarge,AWS,rack,2018,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-db.r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+db.r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.r6g.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,128,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -245,49 +245,49 @@ db.z1d.3xlarge,AWS,rack,2018,12,48,2,12,Xeon Platinum 8151,intel,xeon platinum,s
 db.z1d.6xlarge,AWS,rack,2018,24,48,2,12,Xeon Platinum 8151,intel,xeon platinum,skylake,240,2018,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.z1d.large,AWS,rack,2018,2,48,2,12,Xeon Platinum 8151,intel,xeon platinum,skylake,240,2018,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 db.z1d.xlarge,AWS,rack,2018,4,48,2,12,Xeon Platinum 8151,intel,xeon platinum,skylake,240,2018,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-dc2.8xlarge,AWS,rack,2017,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2017,244,4,61,2,2560,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+dc2.8xlarge,AWS,rack,2017,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2017,244,4,61,2,2560,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 dc2.large,AWS,rack,2017,2,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2017,15,4,61,1,160,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-ds2.8xlarge,AWS,rack,2015,36,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,244,4,61,0,0,1,1600,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+ds2.8xlarge,AWS,rack,2015,36,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,244,4,61,0,0,1,1600,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 ds2.xlarge,AWS,rack,2015,4,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,31,4,61,0,0,2,2000,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-f1.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,976,16,61,1,940,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+f1.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,976,16,61,1,940,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 f1.2xlarge,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,16,61,1,470,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-f1.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,16,61,1,940,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+f1.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,16,61,1,940,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g2.2xlarge,AWS,rack,2013,8,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2013,15,4,15,1,60,0,0,K520,4,225,4,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g2.8xlarge,AWS,rack,2015,32,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2015,60,4,15,2,120,0,0,K520,4,225,4,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-g3.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,488,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-g3.4xlarge,AWS,rack,2017,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,122,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-g3.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,244,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+g3.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,488,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+g3.4xlarge,AWS,rack,2017,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,122,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+g3.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,244,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g3s.xlarge,AWS,rack,2018,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2018,31,8,61,0,0,0,0,Tesla M60,4,300,8,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-g4ad.16xlarge,AWS,rack,2019,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2019,256,32,12,1,2400,0,0,Radeon Pro V520,4,225,16,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+g4ad.16xlarge,AWS,rack,2019,64,96,1,48,EPYC 7R32,amd,epyc,rome,280,2019,256,32,12,1,2400,0,0,Radeon Pro V520,4,225,16,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4ad.4xlarge,AWS,rack,2019,16,96,1,48,EPYC 7R32,amd,epyc,rome,280,2019,64,32,12,1,600,0,0,Radeon Pro V520,4,225,16,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4ad.8xlarge,AWS,rack,2019,32,96,1,48,EPYC 7R32,amd,epyc,rome,280,2019,128,32,12,1,1200,0,0,Radeon Pro V520,4,225,16,2;2;2,2.99;1;5,3,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,192,32,12,1,900,0,0,T4,8,70,16,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-g4dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,1,900,0,0,T4,8,70,16,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+g4dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,1,900,0,0,T4,8,70,16,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.2xlarge,AWS,rack,2019,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,32,32,12,2,225,0,0,T4,8,70,16,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.4xlarge,AWS,rack,2019,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,64,32,12,2,225,0,0,T4,8,70,16,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.8xlarge,AWS,rack,2019,32,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,128,32,12,1,900,0,0,T4,8,70,16,2;2;2,2.99;1;5,3,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.metal,AWS,rack,2019,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,384,32,12,2,900,0,0,T4,8,70,16,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g4dn.xlarge,AWS,rack,2019,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,16,32,12,1,125,0,0,T4,8,70,16,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-h1.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,256,32,8,0,0,8,2000,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+h1.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,256,32,8,0,0,8,2000,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 h1.2xlarge,AWS,rack,2017,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,32,32,8,0,0,1,2000,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-h1.4xlarge,AWS,rack,2017,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,64,32,8,0,0,2,2000,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-h1.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,128,32,8,0,0,4,2000,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+h1.4xlarge,AWS,rack,2017,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,64,32,8,0,0,2,2000,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+h1.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,128,32,8,0,0,4,2000,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 hs1.8xlarge,AWS,rack,2012,16,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2012,117,4,61,0,0,2,2000,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i2.large,AWS,rack,2023,2,32,2,10,Xeon E5-2670 v2,Intel,xeon e5,ivybridge,115,2013,15,32,7.625,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i2.2xlarge,AWS,rack,2013,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,61,4,61,2,800,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i2.2xlarge.elasticsearch,AWS,rack,2013,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,61,32,8,2,800,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-i2.4xlarge,AWS,rack,2013,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,122,4,61,4,800,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-i2.8xlarge,AWS,rack,2013,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,244,4,61,8,800,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+i2.4xlarge,AWS,rack,2013,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,122,4,61,4,800,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+i2.8xlarge,AWS,rack,2013,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,244,4,61,8,800,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i2.xlarge,AWS,rack,2013,4,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,31,4,61,1,800,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i2.xlarge.elasticsearch,AWS,rack,2013,4,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2013,31,32,8,1,800,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-i3.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,32,16,8,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-i3.16xlarge.elasticsearch,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,32,16,8,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+i3.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,32,16,8,1900,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+i3.16xlarge.elasticsearch,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,32,16,8,1900,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i3.2xlarge,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,32,16,1,1900,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i3.2xlarge.elasticsearch,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,32,16,1,1900,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-i3.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-i3.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-i3.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,32,16,4,1900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-i3.8xlarge.elasticsearch,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,32,16,4,1900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+i3.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+i3.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+i3.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,32,16,4,1900,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+i3.8xlarge.elasticsearch,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,32,16,4,1900,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i3.large,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,15,32,16,1,475,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i3.large.elasticsearch,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,15,32,16,1,475,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 i3.metal,AWS,rack,2017,72,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,512,32,16,8,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -320,20 +320,20 @@ m3.medium,AWS,rack,2014,1,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2014
 m3.medium.elasticsearch,AWS,rack,2014,1,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2014,4,32,8,1,4,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m3.xlarge,AWS,rack,2012,4,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2012,15,8,30,2,40,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m3.xlarge.elasticsearch,AWS,rack,2012,4,32,2,8,Xeon E5-2670,intel,xeon e5,sandybridge,115,2012,15,32,8,2,40,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-m4.10xlarge.elasticsearch,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-m4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+m4.10xlarge,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.200000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m4.10xlarge.elasticsearch,AWS,rack,2015,40,48,2,12,Xeon E5-2676 v3,intel,xeon e5,haswell,120,2015,160,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.200000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.2xlarge,AWS,rack,2015,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.2xlarge.elasticsearch,AWS,rack,2015,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-m4.4xlarge.elasticsearch,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+m4.4xlarge,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m4.4xlarge.elasticsearch,AWS,rack,2015,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,64,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.large,AWS,rack,2015,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,8,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.large.elasticsearch,AWS,rack,2015,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,8,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.xlarge,AWS,rack,2015,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m4.xlarge.elasticsearch,AWS,rack,2015,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2015,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m5.12xlarge,AWS,rack,2017,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2017,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5.12xlarge.elasticsearch,AWS,rack,2017,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5.24xlarge,AWS,rack,2017,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2017,384,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5.2xlarge,AWS,rack,2017,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2017,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5.2xlarge.elasticsearch,AWS,rack,2017,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -346,7 +346,7 @@ m5.metal,AWS,rack,2019,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylak
 m5.xlarge,AWS,rack,2017,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2017,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5.xlarge.elasticsearch,AWS,rack,2017,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2017,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m5a.12xlarge,AWS,rack,2018,48,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m5a.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5a.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5a.24xlarge,AWS,rack,2018,96,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,384,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5a.2xlarge,AWS,rack,2018,8,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5a.4xlarge,AWS,rack,2018,16,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,64,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -354,7 +354,7 @@ m5a.8xlarge,AWS,rack,2019,32,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,128,32,12
 m5a.large,AWS,rack,2018,2,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,8,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5a.xlarge,AWS,rack,2018,4,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5ad.12xlarge,AWS,rack,2019,48,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,192,32,12,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m5ad.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5ad.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5ad.24xlarge,AWS,rack,2019,96,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,384,32,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5ad.2xlarge,AWS,rack,2019,8,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,32,32,12,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5ad.4xlarge,AWS,rack,2019,16,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,64,32,12,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -362,7 +362,7 @@ m5ad.8xlarge,AWS,rack,2019,32,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,128,32,1
 m5ad.large,AWS,rack,2019,2,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,8,32,12,1,75,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5ad.xlarge,AWS,rack,2019,4,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,16,32,12,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5d.12xlarge,AWS,rack,2018,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,192,32,12,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m5d.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5d.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5d.24xlarge,AWS,rack,2018,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,384,32,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5d.2xlarge,AWS,rack,2018,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,32,32,12,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5d.4xlarge,AWS,rack,2018,16,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,64,32,12,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -371,7 +371,7 @@ m5d.large,AWS,rack,2018,2,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylak
 m5d.metal,AWS,rack,2019,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,384,32,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5d.xlarge,AWS,rack,2018,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,16,32,12,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5dn.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,192,32,12,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m5dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5dn.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,384,32,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5dn.2xlarge,AWS,rack,2019,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,32,32,12,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5dn.4xlarge,AWS,rack,2019,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,64,32,12,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -380,7 +380,7 @@ m5dn.large,AWS,rack,2019,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,casc
 m5dn.metal,AWS,rack,2021,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2021,384,32,12,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5dn.xlarge,AWS,rack,2019,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,16,32,12,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5n.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,192,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m5n.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m5n.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,256,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5n.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,384,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5n.2xlarge,AWS,rack,2019,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,32,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5n.4xlarge,AWS,rack,2019,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,64,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -395,8 +395,8 @@ m5zn.6xlarge,AWS,rack,2020,24,48,2,12,Xeon Platinum 8252C,intel,xeon platinum,ca
 m5zn.large,AWS,rack,2020,2,48,2,12,Xeon Platinum 8252C,intel,xeon platinum,cascadelake,240,2020,8,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5zn.metal,AWS,rack,2020,48,48,2,12,Xeon Platinum 8252C,intel,xeon platinum,cascadelake,240,2020,192,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m5zn.xlarge,AWS,rack,2020,4,48,2,12,Xeon Platinum 8252C,intel,xeon platinum,cascadelake,240,2020,16,16,12,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
-m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
-m6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+m6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
+m6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6g.2xlarge.elasticsearch,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -410,7 +410,7 @@ m6g.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 m6g.metal,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6g.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6g.xlarge.elasticsearch,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,8,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,2,1425,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,192,32,8,2,1425,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6gd.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6gd.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,8,1,474,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6gd.4xlarge,AWS,rack,2019,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,8,1,950,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -419,9 +419,9 @@ m6gd.large,AWS,rack,2019,2,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 m6gd.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,4,32,8,1,59,0,0,,,,,2;2;2,2.99;1;5,64,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6gd.metal,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,256,32,8,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6gd.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,16,32,8,1,237,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
-m6i.12xlarge,AWS,rack,2021,48,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,192,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m6i.12xlarge,AWS,rack,2021,48,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,192,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,2.666667,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6i.16xlarge,AWS,rack,2021,64,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,256,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-m6i.24xlarge,AWS,rack,2021,96,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+m6i.24xlarge,AWS,rack,2021,96,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6i.2xlarge,AWS,rack,2021,8,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,32,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6i.32xlarge,AWS,rack,2021,128,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,512,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6i.4xlarge,AWS,rack,2021,16,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,64,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -429,39 +429,39 @@ m6i.8xlarge,AWS,rack,2021,32,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,ic
 m6i.large,AWS,rack,2021,2,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,8,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,64,50;0;100,1,35040,0.33;0.2;0.6,0,
 m6i.xlarge,AWS,rack,2021,4,128,2,32,Xeon Platinum 8375C,intel,xeon platinum,icelake,300,2021,16,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,
 mac1.metal,AWS,rack,2020,12,12,1,6,Core i7-8700B,intel,core i7,coffeelake,65,2020,32,32,1,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
-p2.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,732,4,183,0,0,0,0,Tesla K80,16,300,24,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-p2.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,4,183,0,0,0,0,Tesla K80,16,300,24,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+p2.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,732,4,183,0,0,0,0,Tesla K80,16,300,24,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+p2.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,4,183,0,0,0,0,Tesla K80,16,300,24,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p2.xlarge,AWS,rack,2016,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,4,183,0,0,0,0,Tesla K80,16,300,24,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-p3.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,488,32,24,0,0,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+p3.16xlarge,AWS,rack,2017,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,488,32,24,0,0,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p3.2xlarge,AWS,rack,2017,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,61,32,24,0,0,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-p3.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,244,32,24,0,0,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+p3.8xlarge,AWS,rack,2017,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2017,244,32,24,0,0,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p3dn.24xlarge,AWS,rack,2018,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,768,32,24,2,900,0,0,Tesla V100,8,300,32,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p4d.24xlarge,AWS,rack,2020,96,96,2,24,Xeon Platinum 8275CL,intel,xeon platinum,cascadelake,240,2020,1152,32,36,1,8000,0,0,Tesla A100,8,400,40,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.2xlarge,AWS,rack,2014,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,61,4,61,1,160,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.2xlarge.elasticsearch,AWS,rack,2014,8,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,61,4,61,1,160,0,0,,,,,2;2;2,2.99;1;5,5,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-r3.4xlarge,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,1,320,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r3.4xlarge.elasticsearch,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,1,320,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r3.8xlarge,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,2,320,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r3.8xlarge.elasticsearch,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,2,320,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+r3.4xlarge,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,1,320,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r3.4xlarge.elasticsearch,AWS,rack,2014,16,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,122,4,61,1,320,0,0,,,,,2;2;2,2.99;1;5,2.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r3.8xlarge,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,2,320,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r3.8xlarge.elasticsearch,AWS,rack,2014,32,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,244,4,61,2,320,0,0,,,,,2;2;2,2.99;1;5,1.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.large,AWS,rack,2014,2,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,15,4,61,1,32,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.large.elasticsearch,AWS,rack,2014,2,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,15,4,61,1,32,0,0,,,,,2;2;2,2.99;1;5,20,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.xlarge,AWS,rack,2014,4,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,31,4,61,1,80,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r3.xlarge.elasticsearch,AWS,rack,2014,4,40,2,10,Xeon E5-2670 v2,intel,xeon e5,ivybridge,115,2014,31,4,61,1,80,0,0,,,,,2;2;2,2.99;1;5,10,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r4.16xlarge.elasticsearch,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+r4.16xlarge,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r4.16xlarge.elasticsearch,AWS,rack,2016,64,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,488,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,1.125000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.2xlarge,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.2xlarge.elasticsearch,AWS,rack,2016,8,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,61,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,9,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r4.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
-r4.8xlarge.elasticsearch,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+r4.4xlarge,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r4.4xlarge.elasticsearch,AWS,rack,2016,16,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,122,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,4.500000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r4.8xlarge,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+r4.8xlarge.elasticsearch,AWS,rack,2016,32,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,244,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,2.250000,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.large,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,15,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.large.elasticsearch,AWS,rack,2016,2,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,15,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,36,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.xlarge,AWS,rack,2016,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,31,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r4.xlarge.elasticsearch,AWS,rack,2016,4,72,2,18,Xeon E5-2686 v4,intel,xeon e5,broadwell,145,2016,31,8,61,0,0,0,0,,,,,2;2;2,2.99;1;5,18,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r5.12xlarge,AWS,rack,2018,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5.12xlarge.elasticsearch,AWS,rack,2018,48,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-r5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5.24xlarge,AWS,rack,2018,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5.2xlarge,AWS,rack,2018,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5.2xlarge.elasticsearch,AWS,rack,2018,8,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -474,7 +474,7 @@ r5.metal,AWS,rack,2018,96,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylak
 r5.xlarge,AWS,rack,2018,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5.xlarge.elasticsearch,AWS,rack,2018,4,96,2,24,Xeon Platinum 8175M,intel,xeon platinum,skylake,240,2018,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r5a.12xlarge,AWS,rack,2018,48,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5a.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5a.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5a.24xlarge,AWS,rack,2018,96,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5a.2xlarge,AWS,rack,2018,8,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5a.4xlarge,AWS,rack,2018,16,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,128,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -482,7 +482,7 @@ r5a.8xlarge,AWS,rack,2019,32,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,24
 r5a.large,AWS,rack,2018,2,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,16,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5a.xlarge,AWS,rack,2018,4,96,2,24,EPYC 7571,amd,epyc,naple,200,2018,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5ad.12xlarge,AWS,rack,2019,48,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,384,32,24,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5ad.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5ad.16xlarge,AWS,rack,2019,64,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5ad.24xlarge,AWS,rack,2019,96,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,768,32,24,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5ad.2xlarge,AWS,rack,2019,8,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,64,32,24,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5ad.4xlarge,AWS,rack,2019,16,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,128,32,24,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -490,7 +490,7 @@ r5ad.8xlarge,AWS,rack,2019,32,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,256,32,2
 r5ad.large,AWS,rack,2019,2,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,16,32,24,1,75,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5ad.xlarge,AWS,rack,2019,4,96,2,24,EPYC 7571,amd,epyc,naple,200,2019,32,32,24,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5b.12xlarge,AWS,rack,2020,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5b.16xlarge,AWS,rack,2020,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5b.16xlarge,AWS,rack,2020,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5b.24xlarge,AWS,rack,2020,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5b.2xlarge,AWS,rack,2020,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5b.4xlarge,AWS,rack,2020,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,128,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -499,7 +499,7 @@ r5b.large,AWS,rack,2020,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,casca
 r5b.metal,AWS,rack,2020,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5b.xlarge,AWS,rack,2020,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2020,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5d.12xlarge,AWS,rack,2018,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,384,32,24,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5d.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5d.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5d.24xlarge,AWS,rack,2018,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,768,32,24,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5d.2xlarge,AWS,rack,2018,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,64,32,24,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5d.4xlarge,AWS,rack,2018,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,128,32,24,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -508,7 +508,7 @@ r5d.large,AWS,rack,2018,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,casca
 r5d.metal,AWS,rack,2018,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,768,32,24,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5d.xlarge,AWS,rack,2018,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2018,32,32,24,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5dn.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,384,32,24,2,900,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5dn.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,4,600,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5dn.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,768,32,24,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5dn.2xlarge,AWS,rack,2019,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,64,32,24,1,300,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5dn.4xlarge,AWS,rack,2019,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,128,32,24,2,300,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -517,7 +517,7 @@ r5dn.large,AWS,rack,2019,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,casc
 r5dn.metal,AWS,rack,2021,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2021,768,32,24,4,900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5dn.xlarge,AWS,rack,2019,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,32,32,24,1,150,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.12xlarge,AWS,rack,2019,48,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,
-r5n.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
+r5n.16xlarge,AWS,rack,2019,64,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.500000,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.2xlarge,AWS,rack,2019,8,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,64,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.4xlarge,AWS,rack,2019,16,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,128,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -525,8 +525,8 @@ r5n.8xlarge,AWS,rack,2019,32,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,ca
 r5n.large,AWS,rack,2019,2,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,16,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.metal,AWS,rack,2021,96,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2021,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r5n.xlarge,AWS,rack,2019,4,96,2,24,Xeon Platinum 8259CL,intel,xeon platinum,cascadelake,210,2019,32,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,
-r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
-r6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+r6g.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
+r6g.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r6g.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r6g.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
 r6g.2xlarge.elasticsearch,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -540,8 +540,8 @@ r6g.medium,AWS,rack,2019,1,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,
 r6g.metal,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r6g.xlarge,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,
 r6g.xlarge.elasticsearch,AWS,rack,2019,4,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,32,32,16,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-r6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,;usage.instance_per_server is rounded
-r6gd.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+r6gd.12xlarge,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,
+r6gd.12xlarge.elasticsearch,AWS,rack,2019,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,384,32,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r6gd.16xlarge,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,
 r6gd.16xlarge.elasticsearch,AWS,rack,2019,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,512,32,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 r6gd.2xlarge,AWS,rack,2019,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2019,64,32,16,1,474,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,
@@ -605,7 +605,7 @@ x1e.32xlarge,AWS,rack,2017,128,128,4,16,Xeon E7-8880 v3,intel,xeon e7,haswell,15
 x1e.4xlarge,AWS,rack,2017,16,128,4,16,Xeon E7-8880 v3,intel,xeon e7,haswell,150,2017,488,64,61,1,480,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 x1e.8xlarge,AWS,rack,2017,32,128,4,16,Xeon E7-8880 v3,intel,xeon e7,haswell,150,2017,976,64,61,1,960,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 x1e.xlarge,AWS,rack,2017,4,128,4,16,Xeon E7-8880 v3,intel,xeon e7,haswell,150,2017,122,64,61,1,120,0,0,,,,,2;2;2,2.99;1;5,32,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-x2gd.12xlarge,AWS,rack,2021,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2021,768,64,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified;usage.instance_per_server is rounded
+x2gd.12xlarge,AWS,rack,2021,48,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2021,768,64,16,2,1425,0,0,,,,,2;2;2,2.99;1;5,1.333333,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 x2gd.16xlarge,AWS,rack,2021,64,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2021,1024,64,16,2,1900,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 x2gd.2xlarge,AWS,rack,2021,8,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2021,128,64,16,1,475,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 x2gd.4xlarge,AWS,rack,2021,16,64,1,64,Graviton2,Annapurna Labs,Graviton2,Graviton2,150,2021,256,64,16,1,950,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified

--- a/boaviztapi/data/archetypes/cloud/aws.csv
+++ b/boaviztapi/data/archetypes/cloud/aws.csv
@@ -629,7 +629,7 @@ m6a.8xlarge,AWS,rack,2021,32,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,128,32,2
 m6a.12xlarge,AWS,rack,2021,48,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,192,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;106,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m6a.16xlarge,AWS,rack,2021,64,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,256,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,3,50;0;107,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m6a.24xlarge,AWS,rack,2021,96,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;108,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m6a.32xlarge,AWS,rack,2021,128,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;109,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m6a.32xlarge,AWS,rack,2021,128,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,512,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1.5,50;0;109,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m6a.48xlarge,AWS,rack,2021,192,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;110,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m6a.metal,AWS,rack,2021,192,192,2,48,EPYC 7R13,amd,epyc,milan,225,2021,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;111,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c6a.2xlarge,AWS,rack,2022,8,192,2,48.0,EPYC 7R13,AMD,epyc,milan,225.0,,16,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -720,8 +720,8 @@ c7i.24xlarge,AWS,rack,2023,96,192,6,48,Xeon Platinum 8488C,Intel,xeon platinum,S
 c7i.48xlarge,AWS,rack,2023,192,192,6,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,384,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 c7i.xlarge,AWS,rack,2023,4,192,6,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,8,32,12,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 dl1.24xlarge,AWS,rack,2019,96,96,2,24.0,Xeon Platinum 8275CL,Intel,xeon platinum,Cascade Lake,280,,768,32,24,4,1000,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-g4ad.2xlarge,AWS,rack,2020,8,96,1,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,32,32,8,1,300,0,0,AMD Radeon Pro V520,1,,8,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-g4ad.xlarge,AWS,rack,2020,4,96,1,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,16,32,8,1,150,0,0,AMD Radeon Pro V520,1,,8,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+g4ad.2xlarge,AWS,rack,2020,8,96,1,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,32,32,8,1,300,0,0,AMD Radeon Pro V520,1,,8,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+g4ad.xlarge,AWS,rack,2020,4,96,1,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,16,32,8,1,150,0,0,AMD Radeon Pro V520,1,,8,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g5.2xlarge,AWS,rack,2020,8,192,2,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,32,32,24,1,450,0,0,NVIDIA A10G,1,,24,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g5.4xlarge,AWS,rack,2020,16,192,2,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,64,32,24,1,600,0,0,NVIDIA A10G,1,,24,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 g5.8xlarge,AWS,rack,2020,32,192,2,48.0,EPYC 7R32,AMD,epyc,naple,280.0,,128,32,24,1,900,0,0,NVIDIA A10G,1,,24,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -838,11 +838,11 @@ m7i.16xlarge,AWS,rack,2023,64,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,S
 m7i.24xlarge,AWS,rack,2023,96,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,384,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m7i.48xlarge,AWS,rack,2023,192,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,768,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 m7i.xlarge,AWS,rack,2023,4,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,16,32,24,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m7i-flex.2xlarge,AWS,rack,2023,8,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,32,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,4,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m7i-flex.8xlarge,AWS,rack,2023,32,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,128,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m7i-flex.xlarge,AWS,rack,2023,4,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,16,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,8,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m7i-flex.large,AWS,rack,2023,2,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,8,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,16,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-m7i-flex.4xlarge,AWS,rack,2023,16,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,64,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m7i-flex.2xlarge,AWS,rack,2023,8,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,32,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,24,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m7i-flex.8xlarge,AWS,rack,2023,32,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,128,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,6,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m7i-flex.xlarge,AWS,rack,2023,4,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,16,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,48,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m7i-flex.large,AWS,rack,2023,2,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,8,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,96,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+m7i-flex.4xlarge,AWS,rack,2023,16,192,2,48,Xeon Platinum 8488C,Intel,xeon platinum,Sapphire Rapids,385,,64,32,4,0,0,0,0,,,,,2;2;2,2.99;1;5,12,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 mac2.metal,AWS,rack,2021,12,12,1,8,"Apple M1 chip with 8-core CPU, 8-core GPU, and 16-core Neural Engine",,,,,,16,16,1,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p4de.24xlarge,AWS,rack,2019,96,96,2,24,Xeon Platinum 8275CL,Intel,xeon platinum,,240.0,,1152,32,36,8,1000,0,0,NVIDIA A100,8,,80,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 p5.48xlarge,AWS,rack,2023,192,192,2,48.0,EPYC 7R13,AMD,epyc,naple,225.0,,2048,32,64,8,3800,0,0,NVIDIA H100,8,,80,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
@@ -940,7 +940,7 @@ trn1n.32xlarge,AWS,rack,2022,128,128,2,32.0,Xeon Platinum 8375C,Intel,xeon plati
 u-12tb1.112xlarge,AWS,rack,2021,448,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,12288,32,384,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 u-18tb1.112xlarge,AWS,rack,2021,448,448,8,28,Xeon Platinum 8280L,Intel,xeon platinum,Cascade Lake,205,,18432,32,576,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 u-24tb1.112xlarge,AWS,rack,2021,448,448,8,28,Xeon Platinum 8280L,Intel,xeon platinum,Cascade Lake,205,,24576,32,768,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
-u-3tb1.56xlarge,AWS,rack,2021,224,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,3072,32,96,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
+u-3tb1.56xlarge,AWS,rack,2021,224,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,3072,32,96,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 u-6tb1.56xlarge,AWS,rack,2021,224,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,6144,32,192,0,0,0,0,,,,,2;2;2,2.99;1;5,2,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 u-6tb1.112xlarge,AWS,rack,2021,448,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,6144,32,192,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified
 u-9tb1.112xlarge,AWS,rack,2021,448,448,8,28.0,Xeon Platinum 8176M,Intel,xeon platinum,Skylake,165.0,,9216,32,288,0,0,0,0,,,,,2;2;2,2.99;1;5,1,50;0;100,1,35040,0.33;0.2;0.6,0,RAM.capacity not verified


### PR DESCRIPTION
These roundings doesn't really make sense AFAIK. It is unexpected that e.g. `c6g.12xlarge` and `c6g.16xlarge` have the same impact (which was the case before this PR).