### PR TITLE
doc: fix - New Negaoctet link

### DIFF
--- a/docs/docs/Explanations/useful_resources.md
+++ b/docs/docs/Explanations/useful_resources.md
@@ -15,4 +15,4 @@
 
 ## From others
 
-- [NegaOctet public database on Base IMPACTS® ADEME](https://base-impacts.ademe.fr/documents/Negaoctet.zip)
+- [NegaOctet public database on Base Empreinte® ADEME](https://base-empreinte.ademe.fr/documentation/base-impact?idDocument=167) (Requires a free account)


### PR DESCRIPTION
Hi there, 

Due to the ADEME's change from _"Base IMPACT"_ to _"Base Empreinte"_ Negoctet link was broken. Here's the fix with the new one, and a warning about the account now required to access the data.