### PR TITLE
Feat(compatibility): add tool for checking Python compatibility locally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
       if: steps.cache-pipenv.outputs.cache-hit != 'true'
       run: |
         make install
+        
+    - name: Run test suite
+      run: make test
+
+    - name: Run compatibility tests
+      run: make test-compat-min && make test-compat-max
 
     - name: Push package on pypi
       run: API_TOKEN=${{ secrets.DAVID_PYPI_TOKEN }} make distribute

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,5 @@ Check this points if you want to do a pull request :
  * [ ] Is my feature or bug fix unit tested?
  * [ ] Does each of my commits represent an atomic functionality or bug fix?
  * [ ] Is my feature or bug fix related to an issue?
- * [ ] Does my code work with the minimum Python version? You can run `make test-compat-min` to check this
+ * [ ] Is my code compatible with the minimum Python version? You can run `make test-compat-min` to check
+ * [ ] Is my code compatible with the maximum Python version? You can run `make test-compat-max` to check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 Check this points if you want to do a pull request :
 
- * [ ] Is my code written in [PEP8](https://www.python.org/dev/peps/pep-0008/) ?
- * [ ] Are the test passing ?
- * [ ] Is your feature or bug fix unit tested ?
- * [ ] Does each of your commit represent an atomic functionality or bug fix ?
- * [ ] Is your feature or bug fix related to an issue ?
+ * [ ] Is my code written in [PEP8](https://www.python.org/dev/peps/pep-0008/)?
+ * [ ] Are the tests passing?
+ * [ ] Is my feature or bug fix unit tested?
+ * [ ] Does each of my commits represent an atomic functionality or bug fix?
+ * [ ] Is my feature or bug fix related to an issue?
+ * [ ] Does my code work with the minimum Python version? You can run `make test-compat-min` to check this

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
-FROM python:3.9-slim AS build-env
+ARG PY_VERSION=3.9
+FROM python:$PY_VERSION-slim AS build-env
 
 ARG VERSION
 
-COPY . /app
-
 WORKDIR /app
 
+# Install python deps
 RUN python -m pip install --upgrade poetry wheel twine
+
+# Install project deps
+COPY pyproject.toml .
 RUN poetry install --with dev
+
+# Copy code *after* installing deps to avoid unnecessarily invalidating cache
+COPY . .
+
 RUN poetry build
 RUN PROJECT_VERSION=$(poetry version -s) && cp /app/dist/boaviztapi-$PROJECT_VERSION.tar.gz ./boaviztapi-$VERSION.tar.gz
 RUN pip install boaviztapi-$VERSION.tar.gz && cp $(which uvicorn) /app

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TIMESTAMP := $(shell date "+%H.%M-%m-%d-%y")
 DOCKER_NAME := boavizta/boaviztapi:${CURRENT_VERSION}
 SEMVERS := major minor patch
 
-MINIMUM_PY_VERSION=3.8
+MINIMUM_PY_VERSION=3.9
 MAXIMUM_PY_VERSION=3.11
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CURRENT_VERSION := $(shell poetry version -s || sed -n '3s/.*version = "\(.*\)"/
 TIMESTAMP := $(shell date "+%H.%M-%m-%d-%y")
 DOCKER_NAME := boavizta/boaviztapi:${CURRENT_VERSION}
 SEMVERS := major minor patch
+MINIMUM_PY_VERSION=3.8
 
 clean:
 		find . -name "*.pyc" -exec rm -rf {} \;
@@ -14,6 +15,17 @@ install_pip:
 
 test:
 		poetry run pytest
+
+test-compat-min:
+		docker build -t boavizta/boaviztapi-py${MINIMUM_PY_VERSION} \
+			--target build-env \
+			--build-arg VERSION=0.0.1 \
+			--build-arg PY_VERSION=${MINIMUM_PY_VERSION} \
+			.
+		docker run \
+			-v $(shell pwd):/app \
+ 			boavizta/boaviztapi-py${MINIMUM_PY_VERSION} \
+			poetry run pytest
 
 run:
 		poetry run uvicorn boaviztapi.main:app


### PR DESCRIPTION
*Changes*

- Add note about Python compatibility in `CONTRIBUTING.md`
- Small grammar fixes in `CONTRIBUTING.md`
- Add Makefile commands to check min/max python version compatibility
- Tweak Dockerfile order to speed up rebuilds

*Why?*

Reminds people to check Python compatibility when making changes, and gives them a quick way to check (provided they have Docker installed).