### PR TITLE
Tests(compatibility): add matrix test strategy for Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,16 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        version: ["3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.version }}
 
     - name: Install pipenv
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: ["3.9","3.10", "3.11"]
+        version: ["3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
*Change*

Add matrix strategy to run tests on different Python versions in parallel.

*Why?*

If we want to support multiple Python versions, it's good to check their compatibility regularly.