### PR TITLE
fix(docker): fix Docker build and update dev instructions for running image locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 COPY --from=build-env /app /app
-COPY --from=build-env /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
-ENV PYTHONPATH=/usr/local/lib/python3.9/site-packages
+COPY --from=build-env /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CURRENT_VERSION := $(shell poetry version -s || sed -n '3s/.*version = "\(.*\)"/\1/p' pyproject.toml)
-TIMESTAMP := $(shell date "+%H.%M-%m-%d-%y")
+TIMESTAMP := $(shell date "+%m-%d-%y")
 DOCKER_NAME := boavizta/boaviztapi:${CURRENT_VERSION}
 SEMVERS := major minor patch
 
@@ -64,3 +64,6 @@ docker-build:
 
 docker-build-development:
 		docker build -t boavizta/boaviztapi:${TIMESTAMP} .  --build-arg VERSION=${TIMESTAMP}
+
+docker-run-development:
+		docker run -p 5000:5000 boavizta/boaviztapi:${TIMESTAMP}

--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ docker build --build-arg VERSION=`poetry version -s` .
 Run Docker image:
 
 ```sh
-docker run -p 5000:5000/tcp boavizta/boaviztapi:latest
+docker run -p 5000:5000/tcp boavizta/boaviztapi:`poetry version -s`
 ```
 
 #### Alternative (if you don't have Python or Poetry)
 
 ```sh
 make docker-build-development
+
+make docker-run-development
 ```
 
 ### Deploy to AWS as serverless application


### PR DESCRIPTION
*Changes*

- Fix use of `python3.9` missed in upgrade to 3.12
- Remove hours and minutes from timestamp used for building dev images so that we can run subsequent Makefile targets with the same timestamp
- Add Makefile target to allow running built dev image
- Fix instructions for running Docker image locally