### PR TITLE
fix(doc):issue-335-broken-link fix broken relative link

### DIFF
--- a/docs/docs/Explanations/components/case.md
+++ b/docs/docs/Explanations/components/case.md
@@ -68,4 +68,4 @@ With :
 
 ## Usage impacts
 
-Only [power consumption](../usage/elec_conso.md) is implemented. In most cases, enclosure doesn't consume electricity.
+Only [power consumption](../usage/power.md) is implemented. In most cases, enclosure doesn't consume electricity.

--- a/docs/docs/Explanations/components/cpu.md
+++ b/docs/docs/Explanations/components/cpu.md
@@ -93,7 +93,7 @@ with:
 
 ## Usage impacts
 
-Both [power consumption](../usage/elec_conso.md) and [consumption profile](../consumption_profile.md) are implemented.
+Both [power consumption](../usage/power.md) and [consumption profile](../consumption_profile.md) are implemented.
 
 ## Power Consumption profile
 

--- a/docs/docs/Explanations/components/hdd.md
+++ b/docs/docs/Explanations/components/hdd.md
@@ -55,4 +55,4 @@ The HDD disk manufacturing impact is considered as a constant.
 
 ## Usage impact
 
-Only [power consumption](../usage/elec_conso.md) is implemented.
+Only [power consumption](../usage/power.md) is implemented.

--- a/docs/docs/Explanations/components/motherboard.md
+++ b/docs/docs/Explanations/components/motherboard.md
@@ -49,4 +49,4 @@ The motherboard manufacturing impact is considered as a constant.
 
 ## Usage impact
 
-Only [power consumption](../usage/elec_conso.md) is implemented.
+Only [power consumption](../usage/power.md) is implemented.

--- a/docs/docs/Explanations/components/power_supply.md
+++ b/docs/docs/Explanations/components/power_supply.md
@@ -59,6 +59,6 @@ with :
 
 ## Usage impact
 
-Only [power consumption](../usage/elec_conso.md) is implemented.
+Only [power consumption](../usage/power.md) is implemented.
 This shouldn't be used in most cases since the electricity consume by a power supply is consume on behalf of other
 components.

--- a/docs/docs/Explanations/components/ram.md
+++ b/docs/docs/Explanations/components/ram.md
@@ -76,7 +76,7 @@ with:
 
 ## Usage impact
 
-Both [power consumption](../usage/elec_conso.md) and [consumption profile](../consumption_profile.md) are implemented.
+Both [power consumption](../usage/power.md) and [consumption profile](../consumption_profile.md) are implemented.
 
 ## Consumption profile
 

--- a/docs/docs/Explanations/components/ssd.md
+++ b/docs/docs/Explanations/components/ssd.md
@@ -79,4 +79,4 @@ with:
 
 ## Usage impact
 
-Only [power consumption](../usage/elec_conso.md) is implemented.
+Only [power consumption](../usage/power.md) is implemented.

--- a/docs/docs/Explanations/devices/iot_devices.md
+++ b/docs/docs/Explanations/devices/iot_devices.md
@@ -58,5 +58,5 @@ $$
 
 ## Usage impact
 
-Only [power consumption](../usage/elec_conso.md) is implemented.
+Only [power consumption](../usage/power.md) is implemented.
 

--- a/docs/docs/Explanations/devices/server.md
+++ b/docs/docs/Explanations/devices/server.md
@@ -104,7 +104,7 @@ $$
 
 ## Usage impact
 
-Both [power consumption](../usage/elec_conso.md) and [consumption profile](../consumption_profile.md) are implemented.
+Both [power consumption](../usage/power.md) and [consumption profile](../consumption_profile.md) are implemented.
 
 ## Consumption profile
 

--- a/docs/docs/Explanations/usage/usage.md
+++ b/docs/docs/Explanations/usage/usage.md
@@ -2,7 +2,7 @@
 
 Usage impacts can be assessed at device or component level from usage configuration. 
 
-Usage impacts are measured by multiplying a **[duration, a ratio of usage](duration.md)**, an **[impact factor](elec_factors.md)**, and an **[power](elec_conso.md)** :
+Usage impacts are measured by multiplying a **[duration, a ratio of usage](duration.md)**, an **[impact factor](elec_factors.md)**, and an **[power](power.md)** :
 
 ```impact = power * (duration * use_time_ratio) * impact_factor```
 

--- a/docs/docs/Reference/format/server_route.md
+++ b/docs/docs/Reference/format/server_route.md
@@ -38,12 +38,12 @@ In this case, only default values are used.
 
 If any of those following components aren't sent, a default component will be added to the configuration.
 
-* [CPU](../components/cpu.md)
-* [RAM](../components/ram.md)
-* [SSD](../components/ssd.md)
-* [HDD](../components/hdd.md)
-* [power supplies](../components/power_supply.md)
-* [case](../components/case.md)
+* [CPU](../../Explanations/components/cpu.md)
+* [RAM](../../Explanations/components/ram.md)
+* [SSD](../../Explanations/components/ssd.md)
+* [HDD](../../Explanations/components/hdd.md)
+* [power supplies](../../Explanations/components/power_supply.md)
+* [case](../../Explanations/components/case.md)
 
 
 #### Complete input

--- a/docs/docs/q&a.md
+++ b/docs/docs/q&a.md
@@ -28,7 +28,7 @@ See: [Usage methodology](Explanations/usage/usage.md)
 
 Electrical consumption can either be given by the user or modeled according to the context of use and the technical configuration of the asset. 
 
-See: [Electricity methodology](Explanations/usage/elec_conso.md)
+See: [Electricity methodology](Explanations/usage/power.md)
 
 #### How do we compute the impacts of cloud instances?
 


### PR DESCRIPTION
Fixes : #335 
- I looked in git history docs/docs/Explanations/usage/elec_conso.md was renamed docs/docs/Explanations/usage/power.md since commit  c965038
- Relative paths were incorrect in docs/docs/Reference/format/server_route.md
No more warnings when executing `poetry run mkdocs build