### PR TITLE
feat(doc): add github action to check markdown links

### DIFF
--- a/.github/workflows/check_markdown_links.yaml
+++ b/.github/workflows/check_markdown_links.yaml
@@ -1,0 +1,28 @@
+name: Check Markdown links
+run-name: "Check links in documentation"
+
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  
+
+jobs:
+  mkdocs-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: byrnereese/github-action-mkdocs-link-check@1.0       
+      with:
+        folder-path: 'docs/**'
+        file-path: './README.md'
+        local-only: true
+


### PR DESCRIPTION
Fix #359 

# Changes

* Add github action to check markdown links in documentation

# Additional info
According to [github](https://stackoverflow.com/questions/78072432/how-to-enable-a-single-github-action-to-not-block-a-merge), this workflow will have to be setup in the branch protections rules if we want it to be not mandatory for merge.

I have not found a "mandatory" keyword in https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions

# Tests
Tested in https://github.com/jonperron/boaviztapi-dev/pull/1