### PR TITLE
feat(docker): add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore git related files
+.github/
+.gitignore
+
+# Ignore folders not necessary for the docker image
+docs/
+tests/
+
+# Ignore venv if any
+venv/
+
+# Ignore files not necessary for the docker image
+CONTRIBUTING.md
+*.png
+*.json
+LICENSE
+Makefile


### PR DESCRIPTION
First fix for #322 

# Changes
Add a .dockerignore file which allows not to take useless folders and files in the docker image.

Allow to reduce the image size from 596 MB to 524 MB.

# Tests
Tested after a build using `make docker-build`
```shell
docker run -p 5000:5000/tcp boavizta/boaviztapi:`poetry version -s`
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)

```