### PR TITLE
Fix/issues #41 Swagger ui with mult examples

### DIFF
--- a/boaviztapi/routers/openapi_doc/examples.py
+++ b/boaviztapi/routers/openapi_doc/examples.py
@@ -1,4 +1,10 @@
+def convert_to_openapi_example(configuration_examples):
+    return{k: {"summary": "{example} payload".format(example=k),"value":v} for k, v in configuration_examples.items()}
+
+
+
 server_configuration_examples = {
+    "emptyserver": {},
     "DellR740": {"model":
             {
                 "type": "rack"
@@ -34,6 +40,8 @@ server_configuration_examples = {
             "usage_location": "FRA"
         }
     }}
+
+server_configuration_examples_openapi = convert_to_openapi_example(server_configuration_examples)
 
 components_examples = {
     "cpu": {

--- a/boaviztapi/routers/server_router.py
+++ b/boaviztapi/routers/server_router.py
@@ -10,7 +10,7 @@ from boaviztapi.model.device import Device
 from boaviztapi.model.device.server import DeviceServer
 from boaviztapi.routers.openapi_doc.descriptions import server_impact_by_model_description, \
     server_impact_by_config_description, all_archetype_servers, get_archetype_config_desc
-from boaviztapi.routers.openapi_doc.examples import server_configuration_examples
+from boaviztapi.routers.openapi_doc.examples import server_configuration_examples,server_configuration_examples_openapi
 from boaviztapi.service.archetype import get_server_archetype, get_device_archetype_lst
 from boaviztapi.service.verbose import verbose_device
 from boaviztapi.service.impacts_computation import compute_impacts
@@ -60,7 +60,8 @@ async def server_impact_from_model(archetype: str = config["default_server"],
 @server_router.post('/',
                     description=server_impact_by_config_description)
 async def server_impact_from_configuration(
-        server: Server = Body(None, example=server_configuration_examples["DellR740"]),
+        server: Server = Body(None,examples=server_configuration_examples,
+            openapi_examples=server_configuration_examples_openapi),
         verbose: bool = True,
         duration: Optional[float] = config["default_duration"],
         archetype: str = config["default_server"],


### PR DESCRIPTION
Fixes #41 

As far as i can tell, looks like swaggerui does not compute "examples" attribute, but uses specific  openapi_examples https://fastapi.tiangolo.com/tutorial/schema-extra-example/#using-the-openapi_examples-parameter ?
   
- Added openapi_examples attributes to server_impact_from_configuration route
- Added emptyserver exemple to see boaviztapi/routers/openapi_doc/examples.py
- Added function convert_to_openapi_example to convert legacy example to openapi_examples format see boaviztapi/routers/openapi_doc/examples.py

Made these updates only with server route, other examples in  boaviztapi/routers/openapi_doc/examples.py should be modified (with a label as "key"). Should i index all examples with a "default" label and update all other routes?