### PR TITLE
fix(consumption-profile): use family and TDP parameters in CPU completion

### DIFF
--- a/boaviztapi/dto/consumption_profile/consumption_profile.py
+++ b/boaviztapi/dto/consumption_profile/consumption_profile.py
@@ -34,10 +34,12 @@ def mapper_cp(cp_dto: ConsumptionProfile) -> CPUConsumptionProfileModel:
 
 def mapper_cp_cpu(cp_dto: ConsumptionProfileCPU) -> Tuple[CPUConsumptionProfileModel, ComponentCPU]:
     cpu = ComponentCPU()
-    manufacturer, model_range, family = None, None, None
+    manufacturer, model_range, family, tdp = None, None, None, None
 
     if cp_dto.cpu.name is not None:
-        name, manufacturer, family, model_range, tdp, cores, threads, die_size, die_size_source, source = attributes_from_cpu_name(cp_dto.cpu.name)
+        fuzzy_match = attributes_from_cpu_name(cp_dto.cpu.name)
+        if fuzzy_match is not None:
+            manufacturer, family, model_range, tdp = fuzzy_match[1:5]
 
     if cp_dto.cpu.manufacturer is not None:
         cpu.manufacturer.set_input(cp_dto.cpu.manufacturer)
@@ -47,6 +49,16 @@ def mapper_cp_cpu(cp_dto: ConsumptionProfileCPU) -> Tuple[CPUConsumptionProfileM
     if cp_dto.cpu.model_range is not None:
         cpu.model_range.set_input(cp_dto.cpu.model_range)
     elif model_range is not None:
-        cpu.model_range.set_input(model_range)
+        cpu.model_range.set_completed(model_range)
+
+    if cp_dto.cpu.family is not None:
+        cpu.model_range.set_input(cp_dto.cpu.family)
+    elif family is not None:
+        cpu.family.set_completed(family)
+
+    if cp_dto.cpu.tdp is not None:
+        cpu.tdp.set_input(cp_dto.cpu.tdp)
+    elif tdp is not None:
+        cpu.tdp.set_completed(tdp)
 
     return mapper_cp(cp_dto), cpu

--- a/tests/api/test_cp.py
+++ b/tests/api/test_cp.py
@@ -1,15 +1,53 @@
 import pytest
+
 from httpx import AsyncClient, ASGITransport
+from dataclasses import dataclass
+from typing import Optional, Tuple
 
 from boaviztapi.main import app
 
-pytest_plugins = ('pytest_asyncio',)
+pytest_plugins = ("pytest_asyncio",)
 
+
+@dataclass
+class CPUConsumptionProfileTest:
+    name: str
+    expected: Tuple[float, float, float, float]
+
+    tdp: Optional[int] = None
+
+    async def run(self):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            request_body = {"cpu": {"name": self.name}}
+            if self.tdp:
+                request_body["cpu"]["tdp"] = self.tdp
+
+            res = await ac.post("/v1/consumption_profile/cpu", json=request_body)
+
+        res_data: dict = res.json()
+        delta = 0.001
+        assert self.expected[0] == pytest.approx(res_data["a"], delta)
+        assert self.expected[1] == pytest.approx(res_data["b"], delta)
+        assert self.expected[2] == pytest.approx(res_data["c"], delta)
+        assert self.expected[3] == pytest.approx(res_data["d"], delta)
 
 @pytest.mark.asyncio
-async def test_complete_cpu():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        res = await ac.post('/v1/consumption_profile/cpu', json={"cpu": {"name": "intel xeon gold 6134", "tdp": 130}})
+async def test_complete_valid_cpu_manufacturer_family_partial():
+    await CPUConsumptionProfileTest(name="intel xeon", expected=(15.7628, 0.07359, 20.4511, -2.7476)).run()
 
-    assert res.json() == {'a': 35.5688, 'b': 0.2438, 'c': 9.6694, 'd': -0.6087}
+@pytest.mark.asyncio
+async def test_complete_valid_cpu_manufacturer_family():
+    await CPUConsumptionProfileTest(name="intel xeon gold 6134", expected=(35.5688, 0.2438, 9.6694, -0.6087)).run()
+
+@pytest.mark.asyncio
+async def test_complete_valid_cpu_overrides_tdp_if_present():
+    await CPUConsumptionProfileTest(name="intel xeon gold 6134", tdp=100, expected=(50.8479, 0.0630, 20.4511, -0.9990)).run()
+
+@pytest.mark.asyncio
+async def test_complete_alternative_valid_cpu_manufacturer_family():
+    await CPUConsumptionProfileTest(name="amd epyc 7251", expected=(61.0175, 0.0677, 20.4511, -5.5482)).run()
+
+@pytest.mark.asyncio
+async def test_complete_invalid_cpu_returns_default():
+    await CPUConsumptionProfileTest(name="foobar", expected=(171.1813, 0.0354, 36.89, -10.13)).run()


### PR DESCRIPTION
**Problems**

The CPU consumption profile endpoint:

- Does not currently use the family and TDP parameters from the name completion
- Returns a 500 error if the CPU name fuzzy-match fails

**Fix**

- Use all relevant values from fuzzy matching to compute consumption profile
- Tolerate unrecognised CPU name (by taking the default)