### PR TITLE
fix(utils): fix routes v1/utils/version

### DIFF
--- a/boaviztapi/main.py
+++ b/boaviztapi/main.py
@@ -24,23 +24,10 @@ from boaviztapi.routers.server_router import server_router
 from boaviztapi.routers.cloud_router import cloud_router
 from boaviztapi.routers.terminal_router import terminal_router
 from boaviztapi.routers.utils_router import utils_router
+from boaviztapi.utils.get_version import get_version_from_pyproject
 
 from fastapi.responses import HTMLResponse
 
-def get_version_from_pyproject():
-    # List of potential locations for the pyproject.toml file
-    potential_paths = [
-        os.path.join(os.path.dirname(__file__), '../pyproject.toml'),
-        os.path.join(os.path.dirname(__file__), 'pyproject.toml'),
-    ]
-
-    for path in potential_paths:
-        if os.path.exists(path):
-            with open(path, 'r') as f:
-                return toml.loads(f.read())['tool']['poetry']['version']
-
-    # Raise an error if the file is not found in any of the locations
-    raise FileNotFoundError("pyproject.toml not found in expected locations")
 
 # Serverless frameworks adds a 'stage' prefix to the route used to serve applications
 # We have to manage it to expose openapi doc on aws and generate proper links.

--- a/boaviztapi/routers/utils_router.py
+++ b/boaviztapi/routers/utils_router.py
@@ -11,6 +11,7 @@ from boaviztapi.model.component.cpu import attributes_from_cpu_name
 from boaviztapi.routers.openapi_doc.descriptions import country_code, cpu_family, cpu_model_range, ssd_manufacturer, \
     ram_manufacturer, case_type, name_to_cpu, cpu_names, impacts_criteria
 from boaviztapi.service.factor_provider import get_available_countries
+from boaviztapi.utils.get_version import get_version_from_pyproject
 
 utils_router = APIRouter(
     prefix='/v1/utils',
@@ -26,8 +27,7 @@ _ram_manuf = pd.read_csv(os.path.join(data_dir, 'crowdsourcing/ram_manufacture.c
 
 @utils_router.get('/version', description="Get the version of the API")
 async def version():
-    return toml.loads(open(os.path.join(os.path.dirname(__file__), '../../pyproject.toml'), 'r').read())['tool']['poetry'][
-    'version']
+    return get_version_from_pyproject()
 
 @utils_router.get('/country_code', description=country_code)
 async def utils_get_all_countries():

--- a/boaviztapi/utils/get_version.py
+++ b/boaviztapi/utils/get_version.py
@@ -1,0 +1,18 @@
+import os
+import toml
+
+def get_version_from_pyproject():
+    # List of potential locations for the pyproject.toml file
+    potential_paths = [
+        os.path.join(os.path.dirname(__file__), '../../pyproject.toml'),
+        os.path.join(os.path.dirname(__file__), '../pyproject.toml'),
+        os.path.join(os.path.dirname(__file__), 'pyproject.toml'),
+    ]
+
+    for path in potential_paths:
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                return toml.loads(f.read())['tool']['poetry']['version']
+
+    # Raise an error if the file is not found in any of the locations
+    raise FileNotFoundError("pyproject.toml not found in expected locations")

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -523,3 +523,10 @@ async def test_dellR740_server():
                                                'the calculation']},
                      'unit': 'kgCO2eq',
                      'use': {'max': 14900.0, 'min': 380.7, 'value': 6000.0}}}}
+
+@pytest.mark.asyncio
+async def test_utils_version():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get('/v1/utils/version')
+        assert res.status_code == 200


### PR DESCRIPTION
Changelog
* Move function to get version from pyproject file to utils package
* Refactor main and utils_router to use this function

Fix #392 

# Tests
* Docker build :heavy_check_mark: 
* Servers starts successfully :heavy_check_mark: 
```shell
docker run -p 5000:5000/tcp boavizta/boaviztapi:`poetry version -s`                                                                                      
INFO:     Started server process [1]                                                                                                                                                          
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
```
* Endpoint answers 200
```shell
INFO:     172.17.0.1:45490 - "GET /v1/utils/version HTTP/1.1" 200 OK
```
