### PR TITLE
fix(usage): reset dto if provided value is equal to default

### DIFF
--- a/boaviztapi/dto/usage/usage.py
+++ b/boaviztapi/dto/usage/usage.py
@@ -58,8 +58,14 @@ class UsageCloud(UsageServer):
     instance_per_server: Optional[int] = None
 
 
+def _reset_usage_dto_if_matches_config_defaults(usage_dto: Usage):
+    """Reset usage_dto fields to None if they match the config default values."""
+    if usage_dto.usage_location and usage_dto.usage_location.strip().upper() == config["default_location"].upper():
+        usage_dto.usage_location = None
+
 def mapper_usage(usage_dto: Usage, archetype=None) -> ModelUsage:
     usage_model = ModelUsage(archetype=archetype)
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
 
     for elec_factor in usage_dto.elec_factors.__dict__.keys():
         if usage_dto.elec_factors.__dict__[elec_factor] is not None:
@@ -98,6 +104,7 @@ def mapper_usage(usage_dto: Usage, archetype=None) -> ModelUsage:
 def mapper_usage_server(usage_dto: UsageServer,
                         archetype=get_server_archetype(config["default_server"]).get("USAGE")) -> ModelUsageServer:
     usage_model_server = ModelUsageServer(archetype=archetype)
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
 
     for elec_factor in usage_dto.elec_factors.__dict__.keys():
         if usage_dto.elec_factors.__dict__[elec_factor] is not None:
@@ -132,6 +139,7 @@ def mapper_usage_cloud(usage_dto: UsageCloud, archetype=get_cloud_instance_arche
                                                                                          "default_cloud_provider"]).get(
     "USAGE")) -> ModelUsageCloud:
     usage_model_cloud = ModelUsageCloud(archetype=archetype)
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
 
     for elec_factor in usage_dto.elec_factors.__dict__.keys():
         if usage_dto.elec_factors.__dict__[elec_factor] is not None:

--- a/tests/unit/test_use.py
+++ b/tests/unit/test_use.py
@@ -1,6 +1,7 @@
-from boaviztapi.dto.usage.usage import mapper_usage_server
+from boaviztapi.dto.usage.usage import mapper_usage_server, _reset_usage_dto_if_matches_config_defaults, UsageServer
 from boaviztapi.model.device.server import DeviceServer
 from boaviztapi.service.impacts_computation import compute_single_impact
+from boaviztapi import config
 
 
 def test_usage_server_french_mix_1_kw(french_mix_1_kw_dto):
@@ -36,3 +37,33 @@ def test_usage_server_empty_usage(empty_usage_dto):
                                                                                               'be interpreted with caution (see min and max values)']}
     assert compute_single_impact(server, 'use', 'gwp', duration=365 * 24).to_json() == {'max': 64320.0, 'min': 38.55,
                                                                                           'value': 3000.0}
+
+
+def test_reset_usage_dto_if_matches_config_defaults():
+    """Test that usage_location is reset to None when it matches config default"""
+
+    usage_dto = UsageServer()
+    usage_dto.usage_location = "EEE"
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
+    assert usage_dto.usage_location is None
+
+    usage_dto = UsageServer()
+    usage_dto.usage_location = "eee"
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
+    assert usage_dto.usage_location is None
+
+    usage_dto = UsageServer()
+    usage_dto.usage_location = "Eee "
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
+    assert usage_dto.usage_location is None
+
+    usage_dto = UsageServer()
+    usage_dto.usage_location = "FRA"
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
+    assert usage_dto.usage_location == "FRA"
+
+    usage_dto = UsageServer()
+    usage_dto.usage_location = None
+    _reset_usage_dto_if_matches_config_defaults(usage_dto)
+    assert usage_dto.usage_location is None
+


### PR DESCRIPTION
Changelog

* Add function to reset usage_location to None if value is equal to default
* Add test

I tested manually the results from the calls with/without location values (when equal to EEE) and the JSON are similar :+1: 

Fix #418 