### PR TITLE
ci: Generate BoaviztAPI SDK through OpenAPI

### DIFF
--- a/.github/workflows/build_client_sdk_with_poetry.yml
+++ b/.github/workflows/build_client_sdk_with_poetry.yml
@@ -74,4 +74,4 @@ jobs:
         python3 setup.py sdist
         # Publish
         pip3 install pipenv twine
-        pipenv run twine upload --repository pypi --username __token__ --password ${{ secrets.PYPI_TOKEN }} dist/*
+        pipenv run twine upload --repository pypi --username __token__ --password ${{ secrets.PYPI_TOKEN_2025_2026 }} dist/*


### PR DESCRIPTION
Fixes #362.

Hello everyone,

With the development of new features to `boagent` incoming, I needed to make sure that the BoaviztAPI Python SDK was properly generated with each new release of BoaviztAPI.
The problem was that, previously, the generated SDK was uploaded to PyPi with an unverified, personal email address.
I created an organization on PyPi, `boavizta`, with its own email address. The workflow should now work properly. 

Since the last SDK release (in 2024), it seems like some minor changes have been made on how metadata (package version, author, author email, descriptions) is parsed by the OpenAPI SDK generator, and how they are interpreted on the PyPI website for a package page.

 I added some minor corrections in the script to make sure that the metadata is properly added to `setup.py` and `pyproject.toml`, but, of course, feel free to modify anything if you deem it necessary.