### PR TITLE
fix(dockerfile): replace hardcoded path by ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ FROM python:$PY_VERSION-slim AS run-env
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
+ARG PY_VERSION=3.13
 ARG VERSION
 WORKDIR /app
 
@@ -42,7 +43,7 @@ COPY --from=build-env /app/boaviztapi-$VERSION.tar.gz /app/
 RUN pip install --no-cache-dir /app/boaviztapi-$VERSION.tar.gz
 
 # Required in main.py
-COPY --from=build-env /app/pyproject.toml /usr/local/lib/python3.12/site-packages/boaviztapi/
+COPY --from=build-env /app/pyproject.toml /usr/local/lib/python$PY_VERSION/site-packages/boaviztapi/
 
 # Copy uvicorn executable
 RUN pip install --no-cache-dir uvicorn


### PR DESCRIPTION
Docker images built since #442 were broken, because there was a hardcoded path in the Dockerfile. This PR replaces the hardcoded path by the usage of the PY_VERSION, so future updates will be simpler.

`make-docker` is working
```bash
Successfully built 0e7936c9b4b6
Successfully tagged boavizta/boaviztapi:1.3.1
```

`make-docker-build-development` is working
```bash
Successfully built b4f4b83d677a
Successfully tagged boavizta/boaviztapi:01-11-26
```

`make-docker-run-development` is working
```bash
docker run -p 5000:5000 boavizta/boaviztapi:01-11-26
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
```

`docker run` is working with production image
```bash
docker run -p 5000:5000 boavizta/boaviztapi:1.3.13 
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
INFO:     172.17.0.1:42648 - "GET / HTTP/1.1" 307 Temporary Redirect
INFO:     172.17.0.1:42648 - "GET // HTTP/1.1" 200 OK
INFO:     172.17.0.1:42648 - "GET /favicon.ico HTTP/1.1" 404 Not Found
```