### PR TITLE
chore(data): use prod data for test_all_instances, and centralize config for data directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.version }}
 
@@ -44,3 +43,20 @@ jobs:
 
     - name: Run test suite
       run: make test
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+
+    - name: Install poetry
+      run: python -m pip install --upgrade poetry wheel
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Run tests
+      run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ check-csv:
 test:
 		poetry run pytest
 
+test-e2e:
+		poetry run pytest --rune2e
+
 lint:
 		poetry run ruff check
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ $ make run
 $ make run-py
 ```
 
-You can run the tests with `pytest` via `make test`.
+### Tests
+
+You can run the tests with `pytest` via:
+
+- `make test` to run all unit tests (using test data)
+- `make test-e2e` to run end-to-end tests (using "real" data)
 
 ### Create your own docker image and run it
 

--- a/boaviztapi/__init__.py
+++ b/boaviztapi/__init__.py
@@ -4,10 +4,14 @@ from pathlib import Path
 
 import yaml
 
-if "pytest" in sys.modules:
-    data_dir = os.path.join(os.path.dirname(__file__), "../tests/data")
+data_dir_test = os.path.join(os.path.dirname(__file__), "../tests/data")
+data_dir_prod = os.path.join(os.path.dirname(__file__), "data")
+
+# Use test data if using pytest, and not running E2E tests
+if "pytest" in sys.modules and "--rune2e" not in sys.argv:
+    data_dir = data_dir_test
 else:
-    data_dir = os.path.join(os.path.dirname(__file__), "data")
+    data_dir = data_dir_prod
 
 config_file = os.path.join(data_dir, "config.yml")
 config = yaml.safe_load(Path(config_file).read_text())

--- a/boaviztapi/data/archetypes/cloud/gcp.csv
+++ b/boaviztapi/data/archetypes/cloud/gcp.csv
@@ -63,7 +63,7 @@ c4-highmem-16,16,124,0,0,0,c4-highmem,https://cloud.google.com/compute/docs/gene
 c4-highmem-32,32,248,0,0,0,c4-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c4a-standard_1
 c4-highmem-48,48,372,0,0,0,c4-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c4a-standard_1
 c4-highmem-96,96,744,0,0,0,c4-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c4a-standard_1
-c4-highmem-192,192,"1,488",0,0,0,c4-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c4a-standard_1
+c4-highmem-192,192,1488,0,0,0,c4-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c4a-standard_1
 n4-standard-2,2,8,0,0,0,n4-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#n4_series
 n4-standard-4,4,16,0,0,0,n4-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#n4_series
 n4-standard-8,8,32,0,0,0,n4-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#n4_series
@@ -95,7 +95,7 @@ c3d-standard-30,30,120,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/
 c3d-standard-60,60,240,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard
 c3d-standard-90,90,360,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard
 c3d-standard-180,180,720,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard
-c3d-standard-360,360,"1,44",0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard
+c3d-standard-360,360,1440,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard
 c3d-highcpu-4,4,8,0,0,0,c3d-highcpu,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highcpu
 c3d-highcpu-8,8,16,0,0,0,c3d-highcpu,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highcpu
 c3d-highcpu-16,16,32,0,0,0,c3d-highcpu,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highcpu
@@ -110,8 +110,8 @@ c3d-highmem-16,16,128,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/ge
 c3d-highmem-30,30,240,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
 c3d-highmem-60,60,480,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
 c3d-highmem-90,90,720,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
-c3d-highmem-180,180,"1,44",0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
-c3d-highmem-360,360,"2,88",0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
+c3d-highmem-180,180,1440,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
+c3d-highmem-360,360,2880,0,0,0,c3d-highmem,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-highmem
 c3d-standard-8-lssd,8,32,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard-with-local-ssd
 c3d-standard-16-lssd,16,64,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard-with-local-ssd
 c3d-standard-30-lssd,30,120,0,0,0,c3d-standard,https://cloud.google.com/compute/docs/general-purpose-machines?hl=en#c3d-standard-with-local-ssd

--- a/boaviztapi/routers/utils_router.py
+++ b/boaviztapi/routers/utils_router.py
@@ -4,6 +4,7 @@ import pandas as pd
 import toml
 from fastapi import APIRouter, Query
 
+from boaviztapi import data_dir
 from boaviztapi.dto.component.cpu import CPU
 from boaviztapi.model import impact
 from boaviztapi.model.component import ComponentCase
@@ -24,7 +25,6 @@ from boaviztapi.utils.get_version import get_version_from_pyproject
 
 utils_router = APIRouter(prefix="/v1/utils", tags=["utils"])
 
-data_dir = os.path.join(os.path.dirname(__file__), "../data")
 _cpu_specs = pd.read_csv(os.path.join(data_dir, "crowdsourcing/cpu_specs.csv"))
 _ssd_manuf = pd.read_csv(os.path.join(data_dir, "crowdsourcing/ssd_manufacture.csv"))
 _ram_manuf = pd.read_csv(os.path.join(data_dir, "crowdsourcing/ram_manufacture.csv"))

--- a/tests/api/test_cloud.py
+++ b/tests/api/test_cloud.py
@@ -17,10 +17,6 @@ from .util import (
     UNCERTAINTY_WARNING,
 )
 
-cloud_path = os.path.join(
-    os.path.dirname(__file__), "../../boaviztapi/data/archetypes/cloud/"
-)
-
 pytest_plugins = ("pytest_asyncio",)
 
 
@@ -998,39 +994,3 @@ async def test_empty_usage_scw_dev1_l():
     )
 
     await test.check_result()
-
-
-@pytest.mark.asyncio
-async def test_all_instances():
-    try:
-        with open(f"{cloud_path}/providers.csv", "r") as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                provider_name = row.get("provider.name")
-                provider_csv_path = f"{cloud_path}/{provider_name}.csv"
-                try:
-                    with open(provider_csv_path, "r") as f:
-                        reader = csv.DictReader(f)
-                        for row in reader:
-                            instance = row.get("id")
-                            request = CloudInstanceRequest(provider_name, instance)
-
-                            url = request.to_url()
-
-                            transport = ASGITransport(app=app)
-                            async with AsyncClient(
-                                transport=transport, base_url="http://test"
-                            ) as ac:
-                                try:
-                                    await ac.get(url)
-                                except Exception as e:
-                                    pytest.fail(e)
-
-                except FileNotFoundError:
-                    pytest.fail(
-                        f"CSV file for provider '{provider_name}' not found: {provider_csv_path}"
-                    )
-    except FileNotFoundError:
-        pytest.fail(f"provider file not found : {cloud_path}/providers.csv")
-
-    assert True

--- a/tests/api/test_cloud_e2e.py
+++ b/tests/api/test_cloud_e2e.py
@@ -1,0 +1,62 @@
+import csv
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from boaviztapi import data_dir
+from boaviztapi.main import app
+
+from .util import CloudInstanceRequest
+
+cloud_path = os.path.join(data_dir, "archetypes/cloud")
+
+pytest_plugins = ("pytest_asyncio",)
+
+
+# Generate test cases for all instances, across all providers
+def _generate_cloud_provider_urls():
+    urls = []
+    try:
+        with open(f"{cloud_path}/providers.csv", "r") as providers_fh:
+            provider_reader = csv.DictReader(providers_fh)
+            for provider_row in provider_reader:
+                provider_name = provider_row.get("provider.name")
+                provider_csv_path = f"{cloud_path}/{provider_name}.csv"
+                try:
+                    with open(provider_csv_path, "r") as instances_fh:
+                        instances_reader = csv.DictReader(instances_fh)
+                        for instances_row in instances_reader:
+                            instance_id = instances_row.get("id")
+                            request = CloudInstanceRequest(
+                                provider_name, instance_id, use_url_params=True
+                            )
+
+                            print(f"{provider_name} - {instance_id}")
+
+                            urls.append((request.to_url()))
+
+                except FileNotFoundError:
+                    pytest.fail(
+                        f"CSV file for provider '{provider_name}' not found: {provider_csv_path}"
+                    )
+    except FileNotFoundError:
+        pytest.fail(f"provider file not found : {cloud_path}/providers.csv")
+    return urls
+
+
+def pytest_generate_tests(metafunc):
+    if "cloud_provider_url" in metafunc.fixturenames:
+        cloud_provider_urls = _generate_cloud_provider_urls()
+        metafunc.parametrize("cloud_provider_url", cloud_provider_urls)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_all_instances(cloud_provider_url):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get(cloud_provider_url)
+        assert res.status_code in [200, 201], (
+            f"Http error status code {res.status_code}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+# All top-level pytest configuration
+def pytest_configure(config):
+    # E2E marker to mark tests as E2E
+    config.addinivalue_line("markers", "e2e: mark test as an e2e test")
+
+
+# Add option to run only E2E tests. If not specified, all non-E2E tests will run
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rune2e",
+        action="store_true",
+        default=False,
+        help="Run e2e tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    # Run only E2E tests if --rune2e specified, otherwise exclude them
+    if config.getoption("--rune2e"):
+        skip_non_e2e = pytest.mark.skip(reason="--rune2e runs only e2e tests")
+        for item in items:
+            if "e2e" not in item.keywords:
+                item.add_marker(skip_non_e2e)
+        return
+
+    skip_e2e = pytest.mark.skip(reason="need --rune2e option to run")
+    for item in items:
+        if "e2e" in item.keywords:
+            item.add_marker(skip_e2e)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,0 @@
-import os
-
-data_dir = os.path.join(os.path.dirname(__file__), "../data")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,8 +18,7 @@ from boaviztapi.model.component import (
 )
 from boaviztapi.model.device.server import DeviceServer
 from boaviztapi.model.usage import ModelUsageServer
-from tests.unit import data_dir
-
+from boaviztapi import data_dir
 
 # MODEL
 

--- a/tests/unit/test_archetype.py
+++ b/tests/unit/test_archetype.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from boaviztapi.service.archetype import get_archetype
-from tests.unit import data_dir
+from boaviztapi import data_dir
 
 pytest_plugins = ("pytest_asyncio",)
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -3,15 +3,12 @@ import os.path
 
 import pytest
 
-cloud_path = os.path.join(
-    os.path.dirname(__file__), "../../boaviztapi/data/archetypes/cloud/"
-)
-providers_path = os.path.join(
-    os.path.dirname(__file__), "../../boaviztapi/data/archetypes/cloud/providers.csv"
-)
-servers_patch = os.path.join(
-    os.path.dirname(__file__), "../../boaviztapi/data/archetypes/server.csv"
-)
+from boaviztapi import data_dir_prod
+
+# Always use prod data for these tests
+cloud_path = os.path.join(data_dir_prod, "archetypes/cloud")
+providers_path = os.path.join(data_dir_prod, "archetypes/cloud/providers.csv")
+servers_path = os.path.join(data_dir_prod, "archetypes/server.csv")
 
 
 @pytest.fixture
@@ -23,7 +20,7 @@ def providers():
 
 @pytest.fixture
 def valid_platforms():
-    with open(servers_patch, "r") as f:
+    with open(servers_path, "r") as f:
         reader = csv.DictReader(f)
         return {row["id"] for row in reader}
 


### PR DESCRIPTION
## Context

I have modified the work of @ju3ouz4n in https://github.com/Boavizta/boaviztapi/pull/395 to test all cloud instances on the "prod" data. This should guarantee that we no longer have instances in the API that cause errors. 

This is part of the solution suggested for https://github.com/Boavizta/boaviztapi/issues/390.

## Summary

- Centralized all data directory references to use the logic defined in `boaviztapi/__init__.py`
- Fixed inconsistent imports in test files that were importing `data_dir` from the test-specific module
- Added concept of "E2E" tests, which run against production data (and take a long time)
- Modify test config to run E2E tests *only* when specified, which makes `make test` a lot quicker :runner: 

## Changes

- Added `tests/conftest.py` with `--rune2e` pytest option to run E2E tests separately
- Moved cloud E2E tests (`test_all_instances` to `tests/api/test_cloud_e2e.py`), and marked as `e2e`
- Removed use of test `data_dir`
- `boaviztapi/__init__.py` - use test data only if running tests, and `--rune2e` not specified, otherwise use prod data (i.e. for normal operation, and E2E tests)
- Add job in tests workflow to run E2E tests