### PR TITLE
feat(release): add multi-arch builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish release (Docker & Pip)
+name: Publish release (Docker and PyPI)
 
 on:
   release:
@@ -8,12 +8,66 @@ permissions:
   packages: write
 
 jobs:
-
-  build:
+  compat-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install poetry
+      run: python -m pip install --upgrade poetry wheel
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Run test suite
+      run: make test
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: compat-tests
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install poetry
+      run: python -m pip install --upgrade poetry wheel
+
+    - name: Push package on PyPI
+      run: API_TOKEN=${{ secrets.DAVID_PYPI_TOKEN }} make distribute
+
+    - name: Get version
+      id: version
+      run: echo "version=$(poetry version -s)" >> $GITHUB_OUTPUT
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: pypi
+    strategy:
+      matrix:
+        include:
+          - context: .
+            file: Dockerfile
+            image: ghcr.io/boavizta/boaviztapi
+          - context: docs
+            file: docs/Dockerfile
+            image: ghcr.io/boavizta/boaviztapi-doc
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -22,50 +76,19 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
       with:
-        python-version: '3.12'
-
-    - name: Install pipenv
-      run: |
-          python -m pip install --upgrade poetry wheel
-
-    - id: cache-pipenv
-      uses: actions/cache@v4
-      with:
-        path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
-
-    - name: Install dependencies
-      if: steps.cache-pipenv.outputs.cache-hit != 'true'
-      run: |
-        make install
-
-    - name: Run test suite
-      run: make test
-
-    - name: Run compatibility tests
-      run: make test-compat-min && make test-compat-max
-
-    - name: Push package on pypi
-      run: API_TOKEN=${{ secrets.DAVID_PYPI_TOKEN }} make distribute
-
-    - name: Build the api Docker image
-      run: docker build --build-arg VERSION=$(poetry version -s) . --file Dockerfile --tag ghcr.io/boavizta/boaviztapi:latest
-
-    - name : Tag api Docker image
-      run: docker tag ghcr.io/boavizta/boaviztapi:latest ghcr.io/boavizta/boaviztapi:$(poetry version -s)
-
-    - name: Push api images
-      run: docker push -a ghcr.io/boavizta/boaviztapi
-
-    - name: Build doc the Docker image
-      run: docker build docs --file docs/Dockerfile --tag ghcr.io/boavizta/boaviztapi-doc:latest
-
-    - name: Tag doc the Docker image
-      run: docker tag ghcr.io/boavizta/boaviztapi-doc:latest ghcr.io/boavizta/boaviztapi-doc:$(poetry version -s)
-
-    - name: Push doc images
-      run: docker push -a ghcr.io/boavizta/boaviztapi-doc
+        context: ${{ matrix.context }}
+        file: ${{ matrix.file }}
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ${{ matrix.image }}:latest
+          ${{ matrix.image }}:${{ needs.pypi.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,4 @@ Check this points if you want to do a pull request :
  * [ ] Is my feature or bug fix unit tested?
  * [ ] Does each of my commits represent an atomic functionality or bug fix?
  * [ ] Is my feature or bug fix related to an issue?
- * [ ] Is my code compatible with the minimum Python version? You can run `make test-compat-min` to check
- * [ ] Is my code compatible with the maximum Python version? You can run `make test-compat-max` to check
  * [ ] Are the pre-commit checks set up and passing (`make pre-commit-install pre-commit`)?

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@ TIMESTAMP := $(shell date "+%m-%d-%y")
 DOCKER_NAME := boavizta/boaviztapi:${CURRENT_VERSION}
 SEMVERS := major minor patch
 
-MINIMUM_PY_VERSION=3.11
-MAXIMUM_PY_VERSION=3.13
-
 clean:
 		find . -name "*.pyc" -exec rm -rf {} \;
 		rm -rf dist *.egg-info __pycache__
@@ -39,23 +36,6 @@ pre-commit-install:
 pre-commit:
 		poetry run pre-commit run --all-files
 
-define compat-check
-		docker build -t boavizta/boaviztapi-py$(1) \
-			--target build-env \
-			--build-arg PY_VERSION=$(1) \
-			.
-		docker run \
-			-v $(shell pwd):/app \
- 			boavizta/boaviztapi-py$(1) \
-			poetry run pytest
-endef
-
-test-compat-min:
-	$(call compat-check,${MINIMUM_PY_VERSION})
-
-test-compat-max:
-	$(call compat-check,${MAXIMUM_PY_VERSION})
-
 run:
 		poetry run uvicorn boaviztapi.main:app --port 5000
 
@@ -69,7 +49,6 @@ $(SEMVERS):
 
 npm_version:
 		npm version --no-git-tag-version ${CURRENT_VERSION}
-
 
 tag_version:
 		git commit -m "release: bump to ${CURRENT_VERSION}" pyproject.toml package.json package-lock.json


### PR DESCRIPTION
## Summary

This PR adds multi-architecture Docker image builds (linux/amd64 and linux/arm64).

Closes #334.

## Changes

**Note:** the diff is quite hard to read, you can see the full file on the branch [here](https://github.com/Shillaker/boaviztapi/blob/feat/multi-arch-builds/.github/workflows/release.yml).

- Refactor release workflow into three jobs: `compat-test` (compatibility tests), `pypi` (PyPI publish) and `docker` (image build and push)
- Remove use of Docker image to run compat tests (this was actually broken as no test files existed in the image). Instead use `setup-python` Github Action with different versions
- Run all compat tests and image builds in parallel
- Build both images `linux/amd64` and `linux/arm64`
- Remove unused pipenv caching (project uses Poetry)