### PR TITLE
chore(release): reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,23 +1,10 @@
-# Ignore git related files
-.github/
-.gitignore
+# Exclude everything
+*
 
-# Ignore folders not necessary for the docker image
-docs/
-tests/
+# Include files needed for build and release
+!pyproject.toml
+!poetry.lock
+!README.md
 
-# Ignore pre-commit related files
-.pre-commit-config.yaml
-
-# Ignore all CSV format files
-*.fmt
-
-# Ignore venv if any
-venv/
-
-# Ignore files not necessary for the docker image
-CONTRIBUTING.md
-*.png
-*.json
-LICENSE
-Makefile
+# Include code
+!boaviztapi/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,32 @@
 ARG PY_VERSION=3.13
 
 #---------------------------------------------------------------------------------------
-# Stage 1 → Builder image
+# Stage 1 →  Builder image
 #---------------------------------------------------------------------------------------
 FROM python:$PY_VERSION-slim AS build-env
 
-ARG VERSION
 WORKDIR /app
 
-# Install python deps
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
-RUN python -m pip install --no-cache-dir --upgrade poetry wheel twine
+# Install poetry
+RUN pip install --no-cache-dir --upgrade poetry
 
-# Install project deps
+# Copy project files and build wheel
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --with dev --no-root
-
-# Copy code *after* installing deps to avoid unnecessarily invalidating cache
 COPY . .
-
-# Build the project
-RUN poetry build
-RUN PROJECT_VERSION=$(poetry version -s) && \
-    cp /app/dist/boaviztapi-$PROJECT_VERSION.tar.gz ./boaviztapi-$VERSION.tar.gz
+RUN poetry build --format wheel
 
 #---------------------------------------------------------------------------------------
-# Stage 2 → Lambda runtime image
+# Stage 2 →  Lambda runtime image
 #---------------------------------------------------------------------------------------
 FROM public.ecr.aws/lambda/python:$PY_VERSION AS lambda-env
 
 ARG PY_VERSION=3.13
-ARG VERSION
 
-# Copy the built package from build stage and install
-COPY --from=build-env /app/boaviztapi-$VERSION.tar.gz ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir ${LAMBDA_TASK_ROOT}/boaviztapi-$VERSION.tar.gz
+# Copy the built wheel from build stage, install, and clean up
+COPY --from=build-env /app/dist/*.whl ${LAMBDA_TASK_ROOT}/
+RUN pip install --no-cache-dir --no-compile ${LAMBDA_TASK_ROOT}/*.whl && \
+    rm ${LAMBDA_TASK_ROOT}/*.whl && \
+    rm -rf /root/.cache
 
 # Copy pyproject.toml for version info
 COPY --from=build-env /app/pyproject.toml /var/lang/lib/python${PY_VERSION}/site-packages/boaviztapi/
@@ -44,27 +35,26 @@ COPY --from=build-env /app/pyproject.toml /var/lang/lib/python${PY_VERSION}/site
 CMD ["boaviztapi.main.handler"]
 
 #---------------------------------------------------------------------------------------
-# Stage 3 → Runtime image
+# Stage 3 →  Runtime image
 #---------------------------------------------------------------------------------------
-FROM python:$PY_VERSION-slim AS run-env
+FROM python:$PY_VERSION-alpine AS run-env
+
 # Python 3 surrogate unicode handling
 # @see https://click.palletsprojects.com/en/7.x/python3/
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
 ARG PY_VERSION=3.13
-ARG VERSION
 WORKDIR /app
 
-# Copy executable and dependencies
-COPY --from=build-env /app/boaviztapi-$VERSION.tar.gz /app/
-RUN pip install --no-cache-dir /app/boaviztapi-$VERSION.tar.gz
+# Copy wheel, install, and clean up in single layer
+COPY --from=build-env /app/dist/*.whl /app/
+RUN pip install --no-cache-dir --no-compile /app/*.whl && \
+    rm /app/*.whl && \
+    rm -rf /root/.cache
 
 # Required in main.py
 COPY --from=build-env /app/pyproject.toml /usr/local/lib/python$PY_VERSION/site-packages/boaviztapi/
-
-# Copy uvicorn executable
-RUN pip install --no-cache-dir uvicorn
 
 EXPOSE 5000
 CMD ["uvicorn", "boaviztapi.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ pre-commit:
 define compat-check
 		docker build -t boavizta/boaviztapi-py$(1) \
 			--target build-env \
-			--build-arg VERSION=0.0.1 \
 			--build-arg PY_VERSION=$(1) \
 			.
 		docker run \
@@ -84,10 +83,10 @@ distribute:
 		poetry publish --build
 
 docker-build:
-		docker build -t $(DOCKER_NAME) .  --build-arg VERSION=${CURRENT_VERSION}
+		docker build -t $(DOCKER_NAME) .
 
 docker-build-development:
-		docker build -t boavizta/boaviztapi:${TIMESTAMP} .  --build-arg VERSION=${TIMESTAMP}
+		docker build -t boavizta/boaviztapi:${TIMESTAMP} .
 
 docker-run-development:
 		docker run -p 5000:5000 boavizta/boaviztapi:${TIMESTAMP}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Build Docker image:
 make docker-build
 
 # manual build (requires to set version)
-docker build --build-arg VERSION=`poetry version -s` .
+docker build .
 ```
 
 Run Docker image:

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,8 +9,6 @@ provider:
       boavizta-api:
         path: ./
         file: Dockerfile
-        buildArgs:
-          VERSION: "2.0.0"
         buildOptions:
           - "--provenance=false"
           - "--target=lambda-env"


### PR DESCRIPTION
## Summary

Reduces Docker image size by switching to `alpine`, using a whitelist `.dockerignore` approach, and removing unnecessary build artefacts.

```
# Clear all images
docker images -q | xargs docker rmi -f

# Build image on main
git checkout main
docker build --build-arg VERSION=main -t boaviztapi:main --target run-env .

# Build from this PR
git checkout chore/reduce-docker-image-size
docker build --build-arg VERSION=slimmed -t boaviztapi:slimmed --target run-env .
```

Result:

```
$ docker images

IMAGE                ID             DISK USAGE   CONTENT SIZE   EXTRA
boaviztapi:main      dc45bcdc2aeb        646MB          147MB
boaviztapi:slimmed   69ca333c731f        455MB          102MB
```

Closes #322

## Changes

- Switch runtime image from `python:slim` to `python:alpine`
- Use whitelist approach in `.dockerignore` (exclude all, include only needed files)
- Remove unnecessary `VERSION` build argument
- Remove `twine` and dev dependencies from build stage
- Remove unnecessary `poetry install` (`poetry build` works without this)
- Use `.whl` instead of `.tar.gz` to copy from `build-env` to `run-env` (and delete after)
- Combine steps on single lines to reduce layers wherever possible
- Remove redundant `uvicorn` install (already a project dependency)
- Add `--no-compile` flag on `pip install` to avoid generating `.pyc` files ahead of time