### PR TITLE
fix(installation): fix installation of package using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ $ docker run -p 5000:5000 ghcr.io/boavizta/boaviztapi:latest
 
 Access the API at http://localhost:5000.
 
+### Install using pip package
+
+```bash
+$ pip3 install boaviztapi
+```
+
+Run the server locally with:
+
+```bash
+$ uvicorn boaviztapi.main:app --host=localhost --port 5000
+```
+
 ## :computer: Development
 
 ### Prerequisite

--- a/boaviztapi/utils/get_version.py
+++ b/boaviztapi/utils/get_version.py
@@ -1,9 +1,15 @@
 import os
+from importlib import metadata
+
 import toml
 
 
 def get_version_from_pyproject():
-    # List of potential locations for the pyproject.toml file
+    try:
+        return metadata.version("boaviztapi")
+    except metadata.PackageNotFoundError:
+        pass
+
     potential_paths = [
         os.path.join(os.path.dirname(__file__), "../../pyproject.toml"),
         os.path.join(os.path.dirname(__file__), "../pyproject.toml"),
@@ -12,8 +18,7 @@ def get_version_from_pyproject():
 
     for path in potential_paths:
         if os.path.exists(path):
-            with open(path, "r") as f:
-                return toml.loads(f.read())["tool"]["poetry"]["version"]
+            with open(path, "r", encoding="utf-8") as file:
+                return toml.loads(file.read())["tool"]["poetry"]["version"]
 
-    # Raise an error if the file is not found in any of the locations
     raise FileNotFoundError("pyproject.toml not found in expected locations")


### PR DESCRIPTION
Changelog

* Add metadata reading from package, so it does not rely on pyproject.toml (not included in packages usually)
* Revert changes brought to readme while installation using pip was broken

Fix #465