### PR TITLE
bugfix: correct use_time_ratio min/max inversion in simple_impact_use

### DIFF
--- a/boaviztapi/service/impacts_computation.py
+++ b/boaviztapi/service/impacts_computation.py
@@ -107,14 +107,14 @@ def simple_impact_use(
     max_impact = (
         impact_factor.max
         * (model.usage.avg_power.max / 1000)
-        * model.usage.use_time_ratio.min
+        * model.usage.use_time_ratio.max
         * duration
         * model.units.max
     )
     min_impact = (
         impact_factor.min
         * (model.usage.avg_power.min / 1000)
-        * model.usage.use_time_ratio.max
+        * model.usage.use_time_ratio.min
         * duration
         * model.units.min
     )


### PR DESCRIPTION
In `simple_impact_use`, the _use_time_ratio_ uncertainty bounds were swapped: `max_impact` was multiplied by _use_time_ratio.min_ and `min_impact` by _use_time_ratio.max_. Since `use_time_ratio` is a positive multiplier (fraction of time the device is powered on), higher values produce higher impacts. The min/max should follow the same direction as all other terms.

This bug affected ~20 device types routed through simple_impact_use: GPU, SSD, HDD, CASE, MOTHERBOARD, LAPTOP, DESKTOP, TABLET, SMARTPHONE, TELEVISION, BOX, MONITOR, VR headsets/controllers, and all IoT functional block types. It caused the reported uncertainty range (min/max) to be inverted for the use phase of these devices.

The fix aligns simple_impact_use with all other impact functions (cpu_impact_use, server_impact_use, iot_impact_use, ram_impact_use, cloud_impact_use) which correctly pair .min with .min and .max with .max.