### PR TITLE
[AI Assisted] fix(gpu): scale embedded impact by units and include GPU power in server use phase

### DIFF
--- a/boaviztapi/compute/impacts_computation.py
+++ b/boaviztapi/compute/impacts_computation.py
@@ -298,7 +298,8 @@ def gpu_impact_embedded(
             + transport_plane_impact.min
             + end_of_life_impact.min
         )
-        * gpu.units.min,
+        # units is a deterministic count, not a source of uncertainty
+        * gpu.units.value,
         max=(
             casing_impact.max
             + heatsink_impact.max
@@ -311,7 +312,7 @@ def gpu_impact_embedded(
             + transport_plane_impact.max
             + end_of_life_impact.max
         )
-        * gpu.units.max,
+        * gpu.units.value,
     )
 
     impact.allocate(duration, gpu.usage.hours_life_time)

--- a/boaviztapi/compute/impacts_computation.py
+++ b/boaviztapi/compute/impacts_computation.py
@@ -273,36 +273,45 @@ def gpu_impact_embedded(
     end_of_life_impact = _component_impact("end_of_life", "eol", gpu.weight)
 
     impact = Impact(
-        value=casing_impact.value
-        + heatsink_impact.value
-        + pwb_impact.value
-        + gpu_impact.value
-        + vram_impact.value
-        + upstream_transport_impact.value
-        + transport_boat_impact.value
-        + transport_truck_impact.value
-        + transport_plane_impact.value
-        + end_of_life_impact.value,
-        min=casing_impact.min
-        + heatsink_impact.min
-        + pwb_impact.min
-        + gpu_impact.min
-        + vram_impact.min
-        + upstream_transport_impact.min
-        + transport_boat_impact.min
-        + transport_truck_impact.min
-        + transport_plane_impact.min
-        + end_of_life_impact.min,
-        max=casing_impact.max
-        + heatsink_impact.max
-        + pwb_impact.max
-        + gpu_impact.max
-        + vram_impact.max
-        + upstream_transport_impact.max
-        + transport_boat_impact.max
-        + transport_truck_impact.max
-        + transport_plane_impact.max
-        + end_of_life_impact.max,
+        value=(
+            casing_impact.value
+            + heatsink_impact.value
+            + pwb_impact.value
+            + gpu_impact.value
+            + vram_impact.value
+            + upstream_transport_impact.value
+            + transport_boat_impact.value
+            + transport_truck_impact.value
+            + transport_plane_impact.value
+            + end_of_life_impact.value
+        )
+        * gpu.units.value,
+        min=(
+            casing_impact.min
+            + heatsink_impact.min
+            + pwb_impact.min
+            + gpu_impact.min
+            + vram_impact.min
+            + upstream_transport_impact.min
+            + transport_boat_impact.min
+            + transport_truck_impact.min
+            + transport_plane_impact.min
+            + end_of_life_impact.min
+        )
+        * gpu.units.min,
+        max=(
+            casing_impact.max
+            + heatsink_impact.max
+            + pwb_impact.max
+            + gpu_impact.max
+            + vram_impact.max
+            + upstream_transport_impact.max
+            + transport_boat_impact.max
+            + transport_truck_impact.max
+            + transport_plane_impact.max
+            + end_of_life_impact.max
+        )
+        * gpu.units.max,
     )
 
     impact.allocate(duration, gpu.usage.hours_life_time)
@@ -792,6 +801,8 @@ def server_impact_use(
     compute_single_impact(server.cpu, USE, impact_type, duration)
     for ram in server.ram:
         compute_single_impact(ram, USE, impact_type, duration)
+    if server.gpu is not None:
+        compute_single_impact(server.gpu, USE, impact_type, duration)
 
     impact = (
         impact_factor.value

--- a/boaviztapi/models/device/server.py
+++ b/boaviztapi/models/device/server.py
@@ -206,9 +206,11 @@ class DeviceServer(Device):
         # the user explicitly provides an average power per GPU.
         conso_gpu = ImpactFactor(value=0, min=0, max=0)
         if self.gpu is not None and self.gpu.usage.avg_power.is_set():
+            # units is a deterministic count: scale all bounds by units.value so
+            # the uncertainty range only reflects the avg_power bounds.
             conso_gpu.value = self.gpu.usage.avg_power.value * self.gpu.units.value
-            conso_gpu.min = self.gpu.usage.avg_power.min * self.gpu.units.min
-            conso_gpu.max = self.gpu.usage.avg_power.max * self.gpu.units.max
+            conso_gpu.min = self.gpu.usage.avg_power.min * self.gpu.units.value
+            conso_gpu.max = self.gpu.usage.avg_power.max * self.gpu.units.value
 
         return ImpactFactor(
             value=(conso_cpu.value + conso_ram.value + conso_gpu.value)

--- a/boaviztapi/models/device/server.py
+++ b/boaviztapi/models/device/server.py
@@ -202,12 +202,20 @@ class DeviceServer(Device):
                 value=conso_ram.value, min=conso_ram.min, max=conso_ram.max
             )
 
+        # The GPU component has no power model: only account for its power when
+        # the user explicitly provides an average power per GPU.
+        conso_gpu = ImpactFactor(value=0, min=0, max=0)
+        if self.gpu is not None and self.gpu.usage.avg_power.is_set():
+            conso_gpu.value = self.gpu.usage.avg_power.value * self.gpu.units.value
+            conso_gpu.min = self.gpu.usage.avg_power.min * self.gpu.units.min
+            conso_gpu.max = self.gpu.usage.avg_power.max * self.gpu.units.max
+
         return ImpactFactor(
-            value=(conso_cpu.value + conso_ram.value)
+            value=(conso_cpu.value + conso_ram.value + conso_gpu.value)
             * (1 + self.usage.other_consumption_ratio.value),
-            min=(conso_cpu.min + conso_ram.min)
+            min=(conso_cpu.min + conso_ram.min + conso_gpu.min)
             * (1 + self.usage.other_consumption_ratio.min),
-            max=(conso_cpu.max + conso_ram.max)
+            max=(conso_cpu.max + conso_ram.max + conso_gpu.max)
             * (1 + self.usage.other_consumption_ratio.max),
         )
 

--- a/tests/api/test_component.py
+++ b/tests/api/test_component.py
@@ -721,19 +721,19 @@ async def test_complete_gpu_verbose():
         "impacts": {
             "adp": {
                 "description": "Use of minerals and fossil ressources",
-                "embedded": {"max": 0.005819, "min": 0.005819, "value": 0.005819},
+                "embedded": {"max": 0.01164, "min": 0.01164, "value": 0.01164},
                 "unit": "kgSbeq",
                 "use": "not implemented",
             },
             "gwp": {
                 "description": "Total climate change",
-                "embedded": {"max": 238.6, "min": 238.6, "value": 238.6},
+                "embedded": {"max": 477.2, "min": 477.2, "value": 477.2},
                 "unit": "kgCO2eq",
                 "use": "not implemented",
             },
             "pe": {
                 "description": "Consumption of primary energy",
-                "embedded": {"max": 3424.0, "min": 3424.0, "value": 3424.0},
+                "embedded": {"max": 6848.0, "min": 6848.0, "value": 6848.0},
                 "unit": "MJ",
                 "use": "not implemented",
             },
@@ -764,19 +764,19 @@ async def test_complete_gpu_verbose():
             "impacts": {
                 "adp": {
                     "description": "Use of minerals and fossil ressources",
-                    "embedded": {"max": 0.005819, "min": 0.005819, "value": 0.005819},
+                    "embedded": {"max": 0.01164, "min": 0.01164, "value": 0.01164},
                     "unit": "kgSbeq",
                     "use": "not implemented",
                 },
                 "gwp": {
                     "description": "Total climate change",
-                    "embedded": {"max": 238.6, "min": 238.6, "value": 238.6},
+                    "embedded": {"max": 477.2, "min": 477.2, "value": 477.2},
                     "unit": "kgCO2eq",
                     "use": "not implemented",
                 },
                 "pe": {
                     "description": "Consumption of primary energy",
-                    "embedded": {"max": 3424.0, "min": 3424.0, "value": 3424.0},
+                    "embedded": {"max": 6848.0, "min": 6848.0, "value": 6848.0},
                     "unit": "MJ",
                     "use": "not implemented",
                 },

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -34,9 +34,9 @@ async def test_complete_config_server():
             "adp": {
                 "description": "Use of minerals and fossil ressources",
                 "embedded": {
-                    "max": 0.2669,
-                    "min": 0.2594,
-                    "value": 0.2594,
+                    "max": 0.2727,
+                    "min": 0.2652,
+                    "value": 0.2652,
                     "warnings": ["End of life is not included in the calculation"],
                 },
                 "unit": "kgSbeq",
@@ -45,9 +45,9 @@ async def test_complete_config_server():
             "gwp": {
                 "description": "Total climate change",
                 "embedded": {
-                    "max": 1464.0,
-                    "min": 1400.0,
-                    "value": 1464.0,
+                    "max": 1791.0,
+                    "min": 1727.0,
+                    "value": 1791.0,
                     "warnings": ["End of life is not included in the calculation"],
                 },
                 "unit": "kgCO2eq",
@@ -56,9 +56,9 @@ async def test_complete_config_server():
             "pe": {
                 "description": "Consumption of primary energy",
                 "embedded": {
-                    "max": 20020.0,
-                    "min": 19050.0,
-                    "value": 20020.0,
+                    "max": 24620.0,
+                    "min": 23640.0,
+                    "value": 24620.0,
                     "warnings": ["End of life is not included in the calculation"],
                 },
                 "unit": "MJ",

--- a/tests/unit/compute/models/test_model.py
+++ b/tests/unit/compute/models/test_model.py
@@ -1,7 +1,12 @@
+import pytest
+
 from boaviztapi import config
+from boaviztapi.compute.impacts_computation import gpu_impact_embedded
+from boaviztapi.models.component import ComponentCPU, ComponentRAM
 from boaviztapi.models.component.gpu import ComponentGPU, VRAM_DIE_SURFACE_PER_GB
+from boaviztapi.models.device.server import DeviceServer
 from boaviztapi.models.impact import IMPACT_CRITERIAS
-from boaviztapi.models.usage import ModelUsage
+from boaviztapi.models.usage import ModelUsage, ModelUsageServer
 from boaviztapi.data.archetype import get_arch_value, get_component_archetype
 
 
@@ -83,6 +88,81 @@ class TestComponentGPU:
         raw_vram_dies = get_arch_value(archetype, "vram_dies", "default")
         raw_die_area = (raw_vram * VRAM_DIE_SURFACE_PER_GB) / raw_vram_dies
         assert gpu.vram_surface.value > raw_die_area
+
+
+class TestGPUEmbeddedImpact:
+    def test_embedded_impact_scales_linearly_with_units(self):
+        """Regression test for issue #527 (bug 1): embedded GPU impact must
+        scale with ``gpu.units`` like every other component."""
+        gpu_1 = ComponentGPU()
+        gpu_1.units.set_input(1)
+
+        gpu_8 = ComponentGPU()
+        gpu_8.units.set_input(8)
+
+        duration = gpu_1.usage.hours_life_time.value
+
+        value_1, min_1, max_1, _ = gpu_impact_embedded("gwp", duration, gpu_1)
+        value_8, min_8, max_8, _ = gpu_impact_embedded("gwp", duration, gpu_8)
+
+        assert value_1 > 0
+        assert value_8 == pytest.approx(value_1 * 8)
+        assert min_8 == pytest.approx(min_1 * 8)
+        assert max_8 == pytest.approx(max_1 * 8)
+
+
+class TestServerGPUPower:
+    @staticmethod
+    def _build_server(gpu_avg_power=None, gpu_units=4):
+        cpu = ComponentCPU()
+        cpu.units.set_input(2)
+        cpu.core_units.set_input(24)
+        cpu.die_size_per_core.set_input(24.5)
+
+        ram = ComponentRAM()
+        ram.units.set_input(12)
+        ram.capacity.set_input(32)
+        ram.density.set_input(1.79)
+
+        server = DeviceServer()
+        server.cpu = cpu
+        server.ram = [ram]
+        server.usage = ModelUsageServer()
+
+        if gpu_avg_power is not None:
+            gpu = ComponentGPU()
+            gpu.units.set_input(gpu_units)
+            gpu.usage.avg_power.set_input(gpu_avg_power)
+            server.gpu = gpu
+
+        return server
+
+    def test_gpu_power_added_to_server_power_consumption(self):
+        """Regression test for issue #527 (bug 2): the modelled server power
+        must include user-supplied GPU power."""
+        baseline = self._build_server().model_power_consumption().value
+
+        server_with_gpu = self._build_server(gpu_avg_power=400, gpu_units=4)
+        with_gpu = server_with_gpu.model_power_consumption().value
+
+        # 4 GPUs * 400 W of extra power, scaled by the "other consumption" overhead.
+        overhead = 1 + server_with_gpu.usage.other_consumption_ratio.value
+        assert with_gpu > baseline
+        assert with_gpu == pytest.approx(baseline + 4 * 400 * overhead, rel=1e-6)
+
+    def test_gpu_power_ignored_when_avg_power_not_provided(self):
+        """Without a user-supplied avg_power the GPU has no power model, so the
+        server power must be unchanged (GPU embedded impact still applies)."""
+        baseline = self._build_server().model_power_consumption().value
+
+        server_with_gpu = self._build_server()
+        gpu = ComponentGPU()
+        gpu.units.set_input(4)
+        server_with_gpu.gpu = gpu
+
+        assert server_with_gpu.model_power_consumption().value == pytest.approx(
+            baseline
+        )
 
 
 class TestModelUsage:

--- a/tests/unit/compute/test_bottom_up.py
+++ b/tests/unit/compute/test_bottom_up.py
@@ -157,19 +157,19 @@ def test_bottom_up_component_gpu_complete(complete_gpu_model):
     ) == {
         "adp": {
             "description": "Use of minerals and fossil ressources",
-            "embedded": {"max": 0.005819, "min": 0.005819, "value": 0.005819},
+            "embedded": {"max": 0.01164, "min": 0.01164, "value": 0.01164},
             "unit": "kgSbeq",
             "use": "not implemented",
         },
         "gwp": {
             "description": "Total climate change",
-            "embedded": {"max": 238.6, "min": 238.6, "value": 238.6},
+            "embedded": {"max": 477.2, "min": 477.2, "value": 477.2},
             "unit": "kgCO2eq",
             "use": "not implemented",
         },
         "pe": {
             "description": "Consumption of primary energy",
-            "embedded": {"max": 3424.0, "min": 3424.0, "value": 3424.0},
+            "embedded": {"max": 6848.0, "min": 6848.0, "value": 6848.0},
             "unit": "MJ",
             "use": "not implemented",
         },


### PR DESCRIPTION
## Summary

Fixes #527. Two related defects caused **server impacts to be severely undercounted for GPU-dense nodes**:

- **Embedded (Bug 1):** `gpu_impact_embedded()` never multiplied the aggregated impact by `gpu.units`, so a server (or a GPU component request) counted the manufacturing impact of exactly **one** GPU regardless of how many were configured. It now multiplies `value`/`min`/`max` by `gpu.units`, mirroring every other component (`cpu`, `ram`, `ssd`, …).
- **Use (Bug 2):** `DeviceServer.model_power_consumption()` only summed CPU + RAM, so GPU electricity was entirely absent from server impacts. GPU power is now added to the modelled server power when the user supplies `gpu.usage.avg_power`, and `server_impact_use()` computes the GPU component-level use impact.

Because the GPU component has no native power model (the GPU specs dataset has no TDP), Bug 2 is fixed via the minimal, user-driven approach suggested in the issue (option b): honor a user-provided `gpu.usage.avg_power` and include the GPU in the server use phase. This avoids inventing a power model from incomplete data.

## Changes

- `boaviztapi/compute/impacts_computation.py`
  - `gpu_impact_embedded()`: multiply aggregated embedded impact by `gpu.units`.
  - `server_impact_use()`: compute GPU component use impact when a GPU is present.
- `boaviztapi/models/device/server.py`
  - `model_power_consumption()`: include GPU power (`avg_power × units`, subject to the existing other-consumption overhead) when `gpu.usage.avg_power` is set.

## Tests

- New regression tests (`tests/unit/compute/models/test_model.py`):
  - Embedded GPU impact scales linearly with `gpu.units` (1× vs 8×).
  - Server modelled power increases by `units × avg_power × overhead` when GPU power is provided, and is unchanged when it is not.
- Updated existing GPU/server expectations that previously relied on the buggy, units-ignoring values:
  - `tests/unit/compute/test_bottom_up.py::test_bottom_up_component_gpu_complete` (fixture uses `units=2`).
  - `tests/api/test_component.py::test_complete_gpu_verbose` (request uses `units=2`).
  - `tests/api/test_server.py::test_complete_config_server` (config uses `gpu.units=2`).

## Test plan

- [x] `pytest tests/unit` passes.
- [x] `pytest tests/api` passes for all GPU/server-related tests (a few unrelated CPU-verbose / terminal-peripheral tests fail only due to local Windows console encoding / float-precision differences and also fail on `main` without these changes).
- [x] New regression tests fail before the fix and pass after.
