### PR TITLE
fix(openapi): fix description being not displayed after latest fastapi update

### DIFF
--- a/boaviztapi/main.py
+++ b/boaviztapi/main.py
@@ -4,7 +4,7 @@ import anyio
 import markdown
 from fastapi.middleware.cors import CORSMiddleware
 import os
-from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from mangum import Mangum
@@ -28,33 +28,36 @@ from boaviztapi.utils.get_version import get_version_from_pyproject
 
 from fastapi.responses import HTMLResponse
 
+# Serverless frameworks adds a 'stage' prefix to the route used to serve applications
+# We have to manage it to expose openapi doc on aws and generate proper links.
+stage = os.environ.get("STAGE", None)
+openapi_prefix = f"/{stage}" if stage else "/"
+app = FastAPI(root_path=openapi_prefix)
+version = get_version_from_pyproject()
+_logger = logging.getLogger(__name__)
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Startup
+
+def custom_openapi():
+    # Override FastAPI's openapi().
+    if app.openapi_schema:
+        return app.openapi_schema
+
     intro = open(
         os.path.join(os.path.dirname(__file__), "routers/openapi_doc/intro_openapi.md"),
         "r",
         encoding="utf-8",
     )
-    openapi_schema = get_openapi(
+    app.openapi_schema = get_openapi(
         title="BOAVIZTAPI - DEMO",
         version=version,
         description=markdown.markdown(intro.read()),
         routes=app.routes,
         servers=app.servers,
     )
-    app.openapi_schema = openapi_schema
-    yield
+    return app.openapi_schema
 
 
-# Serverless frameworks adds a 'stage' prefix to the route used to serve applications
-# We have to manage it to expose openapi doc on aws and generate proper links.
-stage = os.environ.get("STAGE", None)
-openapi_prefix = f"/{stage}" if stage else "/"
-app = FastAPI(root_path=openapi_prefix, lifespan=lifespan)
-version = get_version_from_pyproject()
-_logger = logging.getLogger(__name__)
+app.openapi = custom_openapi
 
 origins = config.allowed_origins
 


### PR DESCRIPTION
## Description

Following the security fix in https://github.com/Boavizta/boaviztapi/pull/532, description on /docs is not displayed properly in version 2.3.0
<img width="1484" height="235" alt="image" src="https://github.com/user-attachments/assets/7b08d001-1a08-4ebc-a76e-cc65b9efd3ac" />
This change is related to an update on the handling of Swagger UI, introduced in version 0.132.1 of fast API (see https://fastapi.tiangolo.com/release-notes/#01321-2026-02-24)

I need to update the way the openapi property was populated, as the async+lifespan combo is not working anymore.

## Changes
* Add custom_openapi() function to display properly custom description from `routers/openapi_doc/intro_openapi.md` 

## Test
After applying the fix, local branch
<img width="1484" height="1089" alt="image" src="https://github.com/user-attachments/assets/ec1c689b-0e0c-4066-aabe-b30973926cd1" />
