### PR TITLE
Remove polyfill.io dependency from docs.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,6 @@ theme: material
 
 extra_javascript:
     - javascripts/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra:


### PR DESCRIPTION
Remove the polyfill.io script from docs/mkdocs.yml.

The polyfill.io CDN was compromised in a supply chain attack. ES6 features are natively supported in all modern browsers, so the polyfill is not needed for MathJax 3.

Fixes #537.