### PR TITLE
docs: remove polyfill.io from mkdocs config

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,6 @@ theme: material
 
 extra_javascript:
     - javascripts/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra:


### PR DESCRIPTION
## Summary
Removes the external `polyfill.io` script from the MkDocs configuration.

The docs only need the existing local MathJax config and MathJax CDN script; the ES6 polyfill is a legacy external load and is not required for current MkDocs/Material documentation.

## Verification
- `mkdocs build --config-file docs/mkdocs.yml --strict` — passes
- confirmed no `polyfill.io` references remain in `docs/mkdocs.yml` or built docs
- `pytest -q` — 215 passed, 1785 skipped
- `ruff check` — passes
- `ruff format --check` — passes

Closes #537