### PR TITLE
docs: remove polyfill.io from mkdocs config

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,6 @@ theme: material
 
 extra_javascript:
     - javascripts/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra:


### PR DESCRIPTION
Fixes #537

Removes the external polyfill.io script from MkDocs config; MathJax remains.

Prepared and submitted per local approval packet.