### PR TITLE
fix: select test data via explicit env var, not "pytest" in sys.modules

### DIFF
--- a/boaviztapi/__init__.py
+++ b/boaviztapi/__init__.py
@@ -1,13 +1,12 @@
 import os
-import sys
 
 from boaviztapi.utils.config import config
 
 data_dir_test = os.path.join(os.path.dirname(__file__), "..", "tests", "data")
 data_dir_prod = os.path.join(os.path.dirname(__file__), "data")
 
-# Use test data if using pytest, and not running E2E tests
-if "pytest" in sys.modules and "--rune2e" not in sys.argv:
+# Test data is opt-in via an env var set by BoaviztAPI's own test harness (tests/conftest.py)
+if os.environ.get("BOAVIZTAPI_USE_TEST_DATA") == "1" and os.path.isdir(data_dir_test):
     data_dir = data_dir_test
 else:
     data_dir = data_dir_prod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
+import os
 import sys
 
 import pytest
 
-from boaviztapi import config as bv_config
-
 # Check if we're running end-to-end tests
 _running_e2e = "--rune2e" in sys.argv
+
+# Select BoaviztAPI's bundled test data for non-E2E runs. Must be set before
+# boaviztapi is first imported below (its __init__ resolves data_dir at import time).
+if not _running_e2e:
+    os.environ.setdefault("BOAVIZTAPI_USE_TEST_DATA", "1")
+
+from boaviztapi import config as bv_config  # noqa: E402  (must follow the env var above)
 
 # Add overrides for non-E2E tests
 if not _running_e2e:


### PR DESCRIPTION
## Problem

`boaviztapi/__init__.py` selected its data directory by sniffing the test framework:

```python
if "pytest" in sys.modules and "--rune2e" not in sys.argv:
    data_dir = data_dir_test
else:
    data_dir = data_dir_prod
```

`"pytest" in sys.modules` is process-global and true for **any** pytest run — including downstream projects that depend on `boaviztapi` and import it during *their own* test suites. Those consumers get pointed at `boaviztapi/../tests/data`, which lives outside the `boaviztapi/` package and isn't shipped in the wheel, so they hit, at import time:

```
FileNotFoundError: .../site-packages/boaviztapi/../tests/data/factors.yml
```

(here triggered via `boaviztapi.routers.cloud_router`). The same applies to `--rune2e` not being in a downstream consumer's `sys.argv`.

## Fix

Make test-data selection an explicit opt-in owned by the test harness rather than an implicit consequence of pytest being importable:

- **`boaviztapi/__init__.py`** reads `BOAVIZTAPI_USE_TEST_DATA`; an `os.path.isdir(data_dir_test)` guard keeps prod data even if the flag is ever set against an installed wheel. Production code no longer references the test framework at all.
- **`tests/conftest.py`** sets the flag for non-E2E runs, before the first `boaviztapi` import (its `__init__` resolves `data_dir` at import time).

Behaviour for BoaviztAPI's own suite is unchanged: **test data** for non-E2E, **prod data** for `--rune2e`.

## Verification

- `pytest` (non-E2E): `data_dir` → test data; unit suite passes (146 passed).
- `pytest --rune2e`: `data_dir` → prod data.
- Downstream simulation (pytest loaded, flag unset): `data_dir` → prod data — the `FileNotFoundError` no longer occurs.
