### PR TITLE
fix(docs): restore docs/Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,14 @@
+ARG PY_VERSION=3.14
+FROM python:$PY_VERSION-slim
+
+WORKDIR /docs
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+ENTRYPOINT ["mkdocs", "serve"]


### PR DESCRIPTION
## Problem

The v2.4.0 release workflow [failed](https://github.com/Boavizta/boaviztapi/actions/runs/32467861980/job/96728837515):

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

`d5b11bc` ("refactor: dead code") deleted `docs/Dockerfile`, but it was not dead — four things still reference it:

| Reference | Use |
|---|---|
| `.github/workflows/release.yml` | builds/pushes `ghcr.io/boavizta/boaviztapi-doc` |
| `compose.yaml` | builds a `docs` service from `context: docs` |
| `compose-prod.yaml` | runs the published doc image on `:8080` |
| `docs/docs/deploy.md` | documents `docker compose up` serving docs at `localhost:8080` |

`docs/mkdocs.yml` also still sets `dev_addr: '0.0.0.0:8080'`, which only matters for a containerised `mkdocs serve`.

So besides the release failure, `docker compose up` was broken on `main`.

## Fix

Restore `docs/Dockerfile`. One change from the original: dependencies come from `docs/requirements.txt` (identical package set) rather than a hardcoded `pip install` list, so this image and the GitHub Pages job share one source of truth. `requirements.txt` is copied first for layer caching.

## Verification

- `docker build docs/` succeeds
- container returns `HTTP 200` on `:8080`, mkdocs logs 0 errors
- `docker compose build docs` works again
- root API image builds and answers `HTTP 200` on `/v1/server/archetypes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)