### PR TITLE
Allocate GPU embodied impacts by GPU count, and support fractional-GPU instances

### DIFF
--- a/boaviztapi/compute/impacts_computation.py
+++ b/boaviztapi/compute/impacts_computation.py
@@ -868,6 +868,16 @@ def cloud_impact_embedded(
                     )
                 else:
                     continue
+            if component.NAME == "GPU":
+                total_gpu = cloud_instance.platform.get_total_gpu()
+                gpu_units = cloud_instance.gpu_units
+                if gpu_units.has_value() and gpu_units.value and total_gpu:
+                    # gpu_impact_embedded() already scales by the platform's
+                    # GPU units, so this allocates gpu_units whole GPUs -- or a
+                    # fraction of one for vGPU/MIG-partitioned instances.
+                    allocation = gpu_units.value / total_gpu
+                else:
+                    continue
 
             single_impact = compute_single_impact(
                 component, "embedded", impact_type, duration, allocation

--- a/boaviztapi/data/utils/scripts/check_references.py
+++ b/boaviztapi/data/utils/scripts/check_references.py
@@ -325,6 +325,63 @@ def check_cloud_platforms(report, server_ids):
             )
 
 
+def check_cloud_gpu_units(report, server_gpu_units):
+    """Cloud instance `gpu_units` against its platform's `GPU.units`.
+
+    `cloud_impact_embedded` allocates the platform's GPU embodied impacts by
+    `gpu_units / GPU.units`, so the two sides have to be coherent: an instance
+    cannot be sold more GPUs than its host has, and one that claims a GPU its
+    host does not declare silently reports no GPU impact at all.
+
+    chkcsv already enforces that `gpu_units` parses as a float, so this only
+    looks at how the two files line up.
+    """
+    check = "Cloud gpu_units -> archetypes/server.csv GPU.units"
+    for path in cloud_provider_files():
+        for lineno, row in read_rows(path):
+            platform = cell(row, "platform").strip()
+            if platform not in server_gpu_units:
+                # An unresolvable platform is check_cloud_platforms' finding.
+                continue
+
+            location = f"{path.name}:{lineno} ({row['id']})"
+            host_units = server_gpu_units[platform] or 0
+            units = as_float(cell(row, "gpu_units"))
+
+            if units is None or units == 0:
+                if host_units:
+                    report.warning(
+                        check,
+                        location,
+                        f"gpu_units is {cell(row, 'gpu_units').strip() or 'empty'} "
+                        f"but platform '{platform}' has GPU.units={host_units:g}; "
+                        "the instance is billed no GPU impact at all",
+                    )
+                continue
+
+            if units < 0:
+                report.error(check, location, f"gpu_units={units:g} is negative")
+                continue
+
+            if not host_units:
+                report.error(
+                    check,
+                    location,
+                    f"gpu_units={units:g} but platform '{platform}' declares no "
+                    "GPU, so the instance reports no GPU impact",
+                )
+                continue
+
+            if units > host_units:
+                report.error(
+                    check,
+                    location,
+                    f"gpu_units={units:g} exceeds the {host_units:g} GPU(s) of "
+                    f"platform '{platform}'; the instance is allocated "
+                    f"{units / host_units:.2f}x the host's whole GPU impact",
+                )
+
+
 def check_providers(report):
     """Provider CSV names and regions.csv providers against providers.csv."""
     check = "Cloud providers -> archetypes/cloud/providers.csv"
@@ -478,7 +535,12 @@ def main():
 
     cpu_specs = pd.read_csv(CPU_SPECS_CSV)
     gpu_specs = pd.read_csv(GPU_SPECS_CSV)
-    server_ids = {cell(row, "id").strip() for _, row in read_rows(SERVER_CSV)}
+    server_rows = read_rows(SERVER_CSV)
+    server_ids = {cell(row, "id").strip() for _, row in server_rows}
+    server_gpu_units = {
+        cell(row, "id").strip(): as_float(cell(row, "GPU.units"))
+        for _, row in server_rows
+    }
 
     report = Report()
     check_cpu_names(report, cpu_specs)
@@ -486,6 +548,7 @@ def main():
     check_gpu_names(report, gpu_specs)
     check_case_types(report)
     check_cloud_platforms(report, server_ids)
+    check_cloud_gpu_units(report, server_gpu_units)
     check_providers(report)
     check_regions(report)
     check_consumption_profiles(report, cpu_specs)

--- a/boaviztapi/models/device/server.py
+++ b/boaviztapi/models/device/server.py
@@ -237,3 +237,8 @@ class DeviceServer(Device):
 
     def get_total_vcpu(self):
         return self.cpu.threads.value * self.cpu.units.value
+
+    def get_total_gpu(self):
+        if self.gpu is None or not self.gpu.units.has_value():
+            return 0
+        return self.gpu.units.value

--- a/boaviztapi/models/services/cloud_instance.py
+++ b/boaviztapi/models/services/cloud_instance.py
@@ -67,6 +67,11 @@ class ServiceCloudInstance(Service):
             min=get_arch_value(archetype, "ssd_storage", "min"),
             max=get_arch_value(archetype, "ssd_storage", "max"),
         )
+        self.gpu_units = Boattribute(
+            default=get_arch_value(archetype, "gpu_units", "default"),
+            min=get_arch_value(archetype, "gpu_units", "min"),
+            max=get_arch_value(archetype, "gpu_units", "max"),
+        )
 
         for attr, val in kwargs.items():
             if val is not None:

--- a/docs/docs/Explanations/services/cloud.md
+++ b/docs/docs/Explanations/services/cloud.md
@@ -14,8 +14,12 @@ The API will complete the following characteristics depending on the cloud provi
 | memory      | GB    | RAM capacity                    | 32       |
 | ssd_storage | GB    | SSD storage capacity            | 500      |
 | hdd_storage | GB    | HDD storage capacity            | 0        |
+| gpu_units   | None  | Number of GPUs [^1]             | 1        |
 | platform    | None  | Bare metal hosting the instance | a1.metal |
 | usage       | None  | See usage                       |          |
+
+[^1]: May be fractional for instances that share a partitioned GPU (vGPU or MIG), for
+example `0.125` for an eighth of a card.
 
 To add a new cloud instance to the API please refer to the [cloud instance contribution guide](../../contributing/cloud_instance.md).
 
@@ -81,7 +85,19 @@ The API allocate a portion of the impacts of each component to the instance base
 * For RAM :  $\text{RAM}_{\text{instance}}^{\text{embedded}} = \text{RAM}_{\text{server}}^{\text{embedded}} \times \frac{\text{memory}_{\text{instance}}}{\text{RAM}_{\text{server}}}$
 * For SSD storage : $\text{SSD}_{\text{instance}}^{\text{embedded}} = \text{SSD}_{\text{server}}^{\text{embedded}} \times \frac{\text{ssd_storage}_{\text{instance}}}{\text{ssd_storage}_{\text{server}}}$
 * For HDD storage : $\text{HDD}_{\text{instance}}^{\text{embedded}} = \text{HDD}_{\text{server}}^{\text{embedded}} \times \frac{\text{hdd_storage}_{\text{instance}}}{\text{hdd_storage}_{\text{server}}}$
+* For GPU : $\text{GPU}_{\text{instance}}^{\text{embedded}} = \text{GPU}_{\text{server}}^{\text{embedded}} \times \frac{\text{gpu_units}_{\text{instance}}}{\text{GPU.units}_{\text{server}}}$
 * For CPU and all other components : $\text{Component}_{\text{instance}}^{\text{embedded}} = \text{Component}_{\text{server}}^{\text{embedded}} \times \frac{\text{vCPU}_{\text{instance}}}{\text{vCPU}_{\text{server}}}$
+
+!!!warning
+    Before v2.5, the GPU had no allocation of its own and fell through to the vCPU
+    ratio, so a GPU instance was billed a share of the host's cards proportional to
+    its vCPUs rather than to the GPUs it actually gets.
+
+Because $\text{gpu_units}$ may be fractional, an instance sharing a partitioned card
+(vGPU or MIG) is allocated that fraction of a single GPU: an instance with
+$\text{gpu_units} = 0.125$ on a one-GPU platform gets an eighth of the die, VRAM, PWB,
+casing and heatsink impacts. An instance with no GPU, or hosted on a platform that
+declares none, is allocated no GPU impact at all.
 
 The API will sum the embedded impacts of each component to get the embedded impacts of the instance :
 

--- a/docs/docs/Explanations/services/cloud.md
+++ b/docs/docs/Explanations/services/cloud.md
@@ -89,9 +89,8 @@ The API allocate a portion of the impacts of each component to the instance base
 * For CPU and all other components : $\text{Component}_{\text{instance}}^{\text{embedded}} = \text{Component}_{\text{server}}^{\text{embedded}} \times \frac{\text{vCPU}_{\text{instance}}}{\text{vCPU}_{\text{server}}}$
 
 !!!warning
-    Before v2.5, the GPU had no allocation of its own and fell through to the vCPU
-    ratio, so a GPU instance was billed a share of the host's cards proportional to
-    its vCPUs rather than to the GPUs it actually gets.
+    Starting with v2.5, the GPU allocation for an instance type is based on the number of
+    gpu_units instead of its vCPU ratio.
 
 Because $\text{gpu_units}$ may be fractional, an instance sharing a partitioned card
 (vGPU or MIG) is allocated that fraction of a single GPU: an instance with

--- a/docs/docs/contributing/cloud_instance.md
+++ b/docs/docs/contributing/cloud_instance.md
@@ -13,8 +13,11 @@ To add cloud instances for a cloud provider, you will need to create a new CSV f
 | memory      | **Required** | GB    | RAM quantity                     | 96          |
 | ssd_storage |              | GB    | SSD storage quantity (can be 0)  | 0           |
 | hdd_storage |              | GB    | HDD storage quantity (can be 0)  | 0           |
-| gpu_units   |              | unit  | GPU quantity                     | 0           |
+| gpu_units   |              | unit  | GPU quantity [^1]                | 1           |
 | platform    | **Required** |       |                                  | c5.metal    |
+
+[^1]: May be fractional (`0.125`) for instances that share a partitioned GPU.
+See [GPU units](#gpu-units).
 
 
 ### Platform
@@ -30,9 +33,30 @@ The `platform` field must match one of the `id` of the available server archetyp
     It is often impossible to find the exact architecture of the bare metal server. When so use a generic server architecture that matches the instance purpose (storage, compute, memory etc.)
 
 
+### GPU units
+
+`gpu_units` is the number of GPUs the instance is sold with. The API allocates the
+platform's GPU embedded impacts by `gpu_units / GPU.units`, so the two files have to
+agree:
+
+* `gpu_units` must not exceed the `GPU.units` of the platform, otherwise the instance
+  is allocated more than the whole host's GPU impact.
+* If `gpu_units` is set, the platform must declare a `GPU.units` greater than 0 and a
+  `GPU.name`. A platform with `GPU.units = 0` has no GPU at all as far as the API is
+  concerned, and the instance is reported with no GPU impact.
+* Leave it at `0` for an instance sold without a GPU, even when the platform has some.
+
+Fractional values are allowed, for instances that share a GPU partitioned with vGPU or
+MIG. Use the fraction of a whole card, not a count of slices: an instance getting an
+eighth of one GPU is `0.125`. The commercial description of the slice belongs on the
+platform row, in `GPU.name` and `GPU.vram`.
+
+You can check `gpu_units` against the platforms with:
+
+```bash
+poetry run python3 boaviztapi/data/utils/scripts/check_references.py
+```
+
 ### Value ranges
 
 Some values can be inputted using ranges like the following: `default;min;max`. For example, if the value is `2;1;8`, it means that the default value is `2` and the range is from `1` to `8`.
-
-!!! note
-    GPU impacts are now calculated and included in the results. The gpu_units field represents the number of GPUs allocated to the cloud instance.

--- a/docs/docs/contributing/server.md
+++ b/docs/docs/contributing/server.md
@@ -24,7 +24,7 @@ All available servers are stored in a CSV file named `servers.csv` located at `b
 | SSD.capacity                  |               | GB    | SSD storage quantity             | 0                       |
 | HDD.units                     | **Required**  | unit  | Number of HDD                    | 0                       |
 | HDD.capacity                  |               | GB    | HDD storage quantity             | 0                       |
-| GPU.units                     | **Required**  | unit  | GPU quantity                     | 0                       |
+| GPU.units                     | **Required**  | unit  | GPU quantity [^6]                | 0                       |
 | GPU.name                      |               |       | GPU name                         |                         |
 | GPU.vram                      |               | GB    | GPU memory capacity [^5]         |                         |
 | POWER_SUPPLY.units            | **Required**  | unit  | Number of power supply[^2]       | 2                       |
@@ -38,6 +38,8 @@ All available servers are stored in a CSV file named `servers.csv` located at `b
 [^1]: If CPU.name is set and the CPU is available in [cpu_specs.csv](./cpu.md), you do not need to fill in the other CPU attributes. The API will complete them based on the CPU.name.
 
 [^5]: GPU impacts are now calculated and included in the results. The GPU.vram field represents the video RAM capacity in GB.
+
+[^6]: GPU.units is the number of cards physically in the server, and must be greater than 0 for the GPU to be accounted for at all: a row with a GPU.name but GPU.units = 0 is treated as having no GPU. It is also the denominator used to allocate GPU impacts to the cloud instances hosted on this platform, so it must be at least the largest `gpu_units` of those instances. See [Add a new cloud instance](./cloud_instance.md#gpu-units).
 
 [^2]: (Usually power supply duplicated so POWER_SUPPLY.units = 2. Usually POWER_SUPPLY.unit_weight is unknown, in that case use a range such as 2.99;1;5)
 

--- a/tests/api/test_cloud_e2e.py
+++ b/tests/api/test_cloud_e2e.py
@@ -65,8 +65,7 @@ async def test_all_instances(cloud_provider_url):
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_fractional_gpu_instance_reports_gpu_impact():
-    """Azure's NVas_v4 family sells fractions of an MI25 (see issue #563).
-    """
+    """Azure's NVas_v4 family sells fractions of an MI25 (see issue #563)."""
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         embedded = {}

--- a/tests/api/test_cloud_e2e.py
+++ b/tests/api/test_cloud_e2e.py
@@ -60,3 +60,37 @@ async def test_all_instances(cloud_provider_url):
         assert res.status_code in [200, 201], (
             f"Http error status code {res.status_code}"
         )
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_fractional_gpu_instance_reports_gpu_impact():
+    """Azure's NVas_v4 family sells fractions of an MI25 (see issue #563).
+
+    These used to report no GPU impact at all, then a vCPU prorata of the whole
+    card. Each size must now get exactly its advertised fraction.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        embedded = {}
+        for instance_type in ("nv4as_v4", "nv8as_v4", "nv16as_v4", "nv32as_v4"):
+            url = CloudInstanceRequest(
+                "azure", instance_type, use_url_params=True
+            ).to_url()
+            res = await ac.get(f"{url}&verbose=true")
+            assert res.status_code in [200, 201]
+
+            gpu = res.json()["verbose"].get("GPU-1")
+            assert gpu is not None, f"{instance_type} reports no GPU at all"
+            embedded[instance_type] = gpu["impacts"]["gwp"]["embedded"]["value"]
+            assert embedded[instance_type] > 0
+
+        whole_card = embedded["nv32as_v4"]
+        for instance_type, fraction in (
+            ("nv4as_v4", 0.125),
+            ("nv8as_v4", 0.25),
+            ("nv16as_v4", 0.5),
+        ):
+            assert embedded[instance_type] == pytest.approx(
+                whole_card * fraction, rel=0.01
+            ), f"{instance_type} should get {fraction} of one MI25"

--- a/tests/api/test_cloud_e2e.py
+++ b/tests/api/test_cloud_e2e.py
@@ -66,9 +66,6 @@ async def test_all_instances(cloud_provider_url):
 @pytest.mark.asyncio
 async def test_fractional_gpu_instance_reports_gpu_impact():
     """Azure's NVas_v4 family sells fractions of an MI25 (see issue #563).
-
-    These used to report no GPU impact at all, then a vCPU prorata of the whole
-    card. Each size must now get exactly its advertised fraction.
     """
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/tests/unit/compute/test_cloud_gpu_allocation.py
+++ b/tests/unit/compute/test_cloud_gpu_allocation.py
@@ -1,0 +1,111 @@
+"""GPU embodied impacts are allocated to a cloud instance by its GPU count.
+
+Before this, every component that was not RAM/SSD/HDD fell through to a vCPU
+prorata, so a GPU instance was billed a share of the host's GPUs proportional
+to its vCPUs rather than to the GPUs it actually gets. See issue #563.
+"""
+
+import pytest
+
+from boaviztapi.compute.impacts_computation import compute_single_impact
+from boaviztapi.data.archetype import (
+    get_cloud_instance_archetype,
+    get_server_archetype,
+)
+from boaviztapi.models.boattribute import Boattribute
+from boaviztapi.models.device.server import DeviceServer
+from boaviztapi.models.services.cloud_instance import ServiceCloudInstance
+
+DURATION = 8760
+
+
+def instance(instance_type, provider="aws"):
+    return ServiceCloudInstance(
+        archetype=get_cloud_instance_archetype(instance_type, provider)
+    )
+
+
+def gpu_embedded_gwp(cloud_instance):
+    """Embedded GWP booked against the instance's share of the platform GPUs."""
+    compute_single_impact(cloud_instance, "embedded", "gwp", DURATION)
+    gpu = cloud_instance.platform.gpu
+    if gpu is None or "gwp" not in gpu.impacts:
+        return None
+    return gpu.impacts["gwp"]["embedded"].value
+
+
+def vcpu_allocation(cloud_instance):
+    return cloud_instance.vcpu.value / cloud_instance.platform.get_total_vcpu()
+
+
+def test_get_total_gpu_returns_platform_gpu_count():
+    server = DeviceServer(archetype=get_server_archetype("g5.48xlarge"))
+    assert server.get_total_gpu() == server.gpu.units.value == 8
+
+
+def test_get_total_gpu_is_zero_without_gpu():
+    server = DeviceServer(archetype=get_server_archetype("a1.metal"))
+    assert server.gpu is None
+    assert server.get_total_gpu() == 0
+
+
+def test_gpu_allocated_by_gpu_units_not_vcpu():
+    """A g5.xlarge gets 1 of the g5.48xlarge platform's 8 A10Gs."""
+    g5_xlarge = instance("g5.xlarge")
+    g5_full = instance("g5.48xlarge")
+
+    share = gpu_embedded_gwp(g5_xlarge) / gpu_embedded_gwp(g5_full)
+
+    assert share == pytest.approx(1 / 8)
+    # ...and emphatically not the 4/192 vCPU prorata it used to get.
+    assert vcpu_allocation(g5_xlarge) == pytest.approx(4 / 192)
+    assert share != pytest.approx(vcpu_allocation(g5_xlarge))
+
+
+def test_full_platform_instance_keeps_the_whole_gpu_impact():
+    """No regression for an instance that occupies its entire host."""
+    g5_full = instance("g5.48xlarge")
+    platform = DeviceServer(archetype=get_server_archetype("g5.48xlarge"))
+
+    assert g5_full.gpu_units.value == platform.get_total_gpu()
+    assert gpu_embedded_gwp(g5_full) == pytest.approx(
+        compute_single_impact(platform.gpu, "embedded", "gwp", DURATION).value
+    )
+
+
+def test_instance_is_not_overcharged_for_its_vcpu_share():
+    """g5.16xlarge takes a third of the host's vCPUs but only 1 of its 8 GPUs."""
+    g5_16xlarge = instance("g5.16xlarge")
+    g5_full = instance("g5.48xlarge")
+
+    share = gpu_embedded_gwp(g5_16xlarge) / gpu_embedded_gwp(g5_full)
+
+    assert share == pytest.approx(1 / 8)
+    # The vCPU prorata used to bill it 2.67x the GPU it actually gets.
+    assert vcpu_allocation(g5_16xlarge) == pytest.approx(64 / 192)
+    assert share < vcpu_allocation(g5_16xlarge)
+
+
+def test_fractional_gpu_units_get_a_fraction_of_one_gpu():
+    """A vGPU/MIG slice (Azure NVas_v4) gets its fraction of a single card."""
+    one_gpu = instance("g5.xlarge")
+    assert one_gpu.gpu_units.value == 1
+
+    eighth = instance("g5.xlarge")
+    eighth.gpu_units = Boattribute(default=0.125)
+
+    assert gpu_embedded_gwp(eighth) == pytest.approx(gpu_embedded_gwp(one_gpu) / 8)
+
+
+def test_instance_without_gpu_is_unaffected():
+    no_gpu = instance("a1.4xlarge")
+    assert no_gpu.platform.gpu is None
+    assert gpu_embedded_gwp(no_gpu) is None
+
+
+def test_zero_gpu_units_books_no_gpu_impact():
+    """A GPU-less instance sold off a GPU host must not be billed for the cards."""
+    no_gpu = instance("g5.xlarge")
+    no_gpu.gpu_units = Boattribute(default=0)
+
+    assert gpu_embedded_gwp(no_gpu) is None


### PR DESCRIPTION
Closes #563.

## Problem

`cloud_impact_embedded()` picked an allocation ratio per component type — RAM by memory, SSD/HDD by capacity — and let **everything else, GPU included, fall through to `vcpu / platform.get_total_vcpu()`**. The `gpu_units` column present in every `archetypes/cloud/*.csv` was never read at runtime.

So a GPU instance was billed a share of its host's cards proportional to its vCPUs rather than to the GPUs it actually gets. That is wrong for **99 of the 124** GPU-bearing instances, by factors from **0.08x to 5.33x**:

| instance | GPUs on instance | GPUs on host | vCPU allocation | GPU allocation | previous error |
|---|---|---|---|---|---|
| `aws/g4dn.16xlarge` | 1 | 8 | 0.667 | 0.125 | 5.3x over |
| `gcp/g2-standard-32` | 1 | 16 | 0.286 | 0.063 | 4.6x over |
| `aws/g5.xlarge` | 1 | 8 | 0.021 | 0.125 | 6x under |
| `ovhcloud/t2-le-45` | 1 | 2 | 0.059 | 0.500 | 8.5x under |
| `aws/gr6.4xlarge` | 1 | 1 | 0.083 | 1.000 | 12x under |

It also made fractional-GPU instances inexpressible. Azure's NVas_v4 family sells eighths, quarters and halves of an MI25 and returned **no GPU impact at all**.

Use-phase GPU power is a separate, known gap and is explicitly out of scope here.

## Changes

**1. Allocate the GPU by GPU count** (`f046a0c`)

- `ServiceCloudInstance.gpu_units`, read from the instance archetype like `vcpu`/`memory`/`ssd_storage`. It surfaces in verbose output automatically.
- `DeviceServer.get_total_gpu()`, returning 0 when the platform declares no GPU.
- A `GPU` branch in `cloud_impact_embedded()` allocating `gpu_units / get_total_gpu()`, skipping the component when either is unset or zero — the existing SSD/HDD pattern.

`gpu_impact_embedded()` already scales by the platform's GPU units, so the allocation yields whole GPUs, or a fraction of one for the vGPU/MIG instances that `cloud.fmt` now types as `float`.

**2. Cross-check the data** (`d69afcc`)

`gpu_units` becomes load-bearing for the first time, so `check_references.py` gains `check_cloud_gpu_units`:

| level | condition |
|---|---|
| ERROR | `gpu_units` exceeds the platform's `GPU.units` |
| ERROR | `gpu_units` set but the platform declares no GPU |
| ERROR | `gpu_units` negative |
| WARNING | platform has GPUs but `gpu_units` is 0 or empty |

It doesn't re-check that `gpu_units` parses as a float — chkcsv already enforces `type=float` in pre-commit — and stays silent on an unresolvable platform, leaving that to `check_cloud_platforms`.

**3. Documentation** (`7bfe661`)

- `Explanations/services/cloud.md` said GPU fell under *"CPU and all other components"*, allocated by the vCPU ratio. Added the GPU formula, a note on the pre-2.5 behaviour, and `gpu_units` to the characteristics table, where it was missing.
- `contributing/cloud_instance.md` carried the note that GPU impacts *"are now calculated"* — aspirational when written, since nothing read the field. Replaced with a **GPU units** section giving the rules the data must satisfy, how to express a vGPU/MIG slice as a fraction of a card, and the command to check it.
- `contributing/server.md` gains a footnote on `GPU.units`: a row with a `GPU.name` but `GPU.units = 0` is treated as having no GPU, and the value is the denominator for every instance on that platform.

## Acceptance criteria

All six from the issue, verified against production data:

- [x] GPU embodied impact scales with `gpu_units`, not vCPU — 99 of 124 instances corrected
- [x] `g4dn.metal` still reports 100% of the host's GPU impact
- [x] `g5.xlarge` reports 1/8 of `g5.48xlarge`; `g4dn.16xlarge` reports 1/8, not 5.33/8
- [x] `gpu_units = 0.125` reports 1/8 of one GPU's embodied impact
- [x] Azure `nv4as_v4` returns a non-zero `GPU-1` entry in verbose output
- [x] Instances with no GPU are unaffected

`g5.xlarge` now reports **244.9 kgCO2eq** GPU embedded, matching the 245 the issue predicted from first principles.

## Testing

- 8 unit tests in `tests/unit/compute/test_cloud_gpu_allocation.py`, ratio-based so they don't ossify impact-factor values
- 1 e2e test walking the whole Azure NVas_v4 fractional ladder against production data
- **236 passed** in unit mode, **1953 passed** in e2e mode (every instance of every provider), stable under random ordering
- `ruff check` and `ruff format --check` clean; `mkdocs build --strict` clean

The new `check_references.py` branches were exercised against a synthetic provider CSV: all four failure modes fire, and valid rows (full platform, partial, fractional, GPU-less) stay silent.

## Two data rows now fail the new check

Pre-existing errors that the vCPU prorata was masking. Both are allocated **2.00x their host's entire GPU impact**:

```
gcp.csv:332 (a2-highgpu-16g): gpu_units=16 exceeds the 8 GPU(s) of platform 'a2-highgpu'
ovhcloud.csv:48 (t2-le-180):  gpu_units=4 exceeds the 2 GPU(s) of platform 'GPU_t2'
```

I've left them unfixed deliberately — correcting them needs verification against provider docs (does GCP's `a2-highgpu` platform row need 16 A100s, or does the instance belong on a different platform?), and guessing would bake in a different error. They now fail `check_references.py`, so they can't be forgotten. **Worth resolving before merge.**

## Also noticed, not addressed

- `ComponentGPU.name.value` still raises `RecursionError`, so every GPU completes from the generic "Large GPU" default and an A10G and an H100 get near-identical embodied impacts. The issue calls this out as a distinct defect; it caps the value of the fractional-GPU work and deserves its own issue.
- `tests/data/archetypes/` is a stale snapshot: it has `CPU.vcpu` where `server.csv` has `CPU.threads`, so the g4dn platform's `get_total_vcpu()` raises. The unit tests use the g5 family, which resolves cleanly. `contributing/server.md` documents the same stale `CPU.vcpu` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
